### PR TITLE
Add initial draft to include new FMI 3.0 data types

### DIFF
--- a/docs/4___common_content.adoc
+++ b/docs/4___common_content.adoc
@@ -170,7 +170,9 @@ _[ Note that in the case of connectors the use of a type element itself is optio
 [width="100%",cols="33%,67%",options="header",]
 |===
 |Element |Description
-|Real / Integer / +
+|Real / Float64 / Float32 / +
+Integer / Int8 / UInt8 / Int16 / UInt16 / +
+Int32 / UInt32 / Int64 / UInt64 / +
 Boolean / String / Enumeration / Binary |Exactly one of these elements *MUST* be present to specify the type of the element. See below for details.
 |===
 
@@ -188,11 +190,87 @@ If the attribute is not supplied, the unit is determined through default mechani
 | |
 |===
 
+===== Float64
+
+image:images/image12.png[image,width=226,height=95]
+
+This type specifies that the connector in question represents an IEEE754 double precision floating point number.
+
+[width="100%",cols="28%,72%",options="header",]
+|===
+|Attribute |Description
+|unit |This optional attribute gives the name of a unit. The name *MUST* match the name of a Unit entry in the Units XML element of the top-level element of the file. +
+If the attribute is not supplied, the unit is determined through default mechanisms: For FMU components, the unit of the underlying variable would be used, or no unit, if no unit is specified. For systems, the units of connected underlying connectors could be used if unambiguous. If a unit (or its absence) cannot be deduced unambinguously, the user should be informed of this error. Notwithstanding these mechanisms, unitless variables of type Float64 are supported.
+| |
+|===
+
+===== Float32
+
+image:images/image12.png[image,width=226,height=95]
+
+This type specifies that the connector in question represents an IEEE754 single precision floating point number.
+
+[width="100%",cols="28%,72%",options="header",]
+|===
+|Attribute |Description
+|unit |This optional attribute gives the name of a unit. The name *MUST* match the name of a Unit entry in the Units XML element of the top-level element of the file. +
+If the attribute is not supplied, the unit is determined through default mechanisms: For FMU components, the unit of the underlying variable would be used, or no unit, if no unit is specified. For systems, the units of connected underlying connectors could be used if unambiguous. If a unit (or its absence) cannot be deduced unambinguously, the user should be informed of this error. Notwithstanding these mechanisms, unitless variables of type Float32 are supported.
+| |
+|===
+
 ===== Integer
 
 image:images/image13.png[image,width=56,height=28]
 
 This type specifies that the connector in question represents a 32-bit signed integer number.
+
+===== Int8
+
+image:images/image13.png[image,width=56,height=28]
+
+This type specifies that the connector in question represents a 8-bit signed integer number.
+
+===== UInt8
+
+image:images/image13.png[image,width=56,height=28]
+
+This type specifies that the connector in question represents a 8-bit unsigned integer number.
+
+===== Int16
+
+image:images/image13.png[image,width=56,height=28]
+
+This type specifies that the connector in question represents a 16-bit signed integer number.
+
+===== UInt16
+
+image:images/image13.png[image,width=56,height=28]
+
+This type specifies that the connector in question represents a 16-bit unsigned integer number.
+
+===== Int32
+
+image:images/image13.png[image,width=56,height=28]
+
+This type specifies that the connector in question represents a 32-bit signed integer number.
+
+===== UInt32
+
+image:images/image13.png[image,width=56,height=28]
+
+This type specifies that the connector in question represents a 32-bit unsigned integer number.
+
+===== Int64
+
+image:images/image13.png[image,width=56,height=28]
+
+This type specifies that the connector in question represents a 64-bit signed integer number.
+
+===== UInt64
+
+image:images/image13.png[image,width=56,height=28]
+
+This type specifies that the connector in question represents a 64-bit unsigned integer number.
 
 ===== Boolean
 
@@ -257,7 +335,7 @@ image:images/image19.png[image,width=323,height=187]
 This element provides for a linear transformation of the source value to the target value, i.e. in the calculation target = factor * source + offset.
 
 Note that conversions based on different units are performed, unless prevented by suppressUnitConversion, prior to the application of the linear transformation, i.e. the value of source is already converted to the target unit in the formula above.
-Linear transformations are only valid for connectors of Real type.
+Linear transformations are only valid for connectors of Real, Float64 or Float32 type.
 
 [width="100%",cols="28%,72%",options="header",]
 |===

--- a/docs/4___common_content.adoc
+++ b/docs/4___common_content.adoc
@@ -365,7 +365,7 @@ In that case values not mapped by a mapping entry are kept unchanged.
 
 image:images/image21.png[image,width=546,height=155]
 
-This element provides for a transformation of integer values based on a mapping table and is valid for connectors of Integer or Enumeration type.
+This element provides for a transformation of integer values based on a mapping table and is valid for connectors of all the integer types and Enumeration type.
 Each mapping table entry is provided by a MapEntry element.
 Mapping entries *MUST* be unambiguous, i.e. for a given source value at a maximum one entry specifying that source value *MUST* be present.
 The mapping does not have to be complete, i.e. partial mappings *CAN* be specified.
@@ -374,6 +374,10 @@ In that case values not mapped by a mapping entry are kept unchanged.
 When mapping to an Enumeration type, the target value *MUST* be a valid enumeration value for that type.
 When mapping from an Enumeration type, the source value *MUST* be a valid enumeration value for that type.
 This transformation can be applied between connectors of different Enumeration types, as long as all resulting target values are valid in the target Enumeration type.
+
+The target values provided in transformation entries *MUST* be limited to the value space of the target connector.
+The source values provided in transformation entries *CAN* exceed the value space of the source connector.
+Such entries are ignored in the mapping process.
 
 [width="100%",cols="28%,72%",options="header",]
 |===

--- a/docs/5___ssd.adoc
+++ b/docs/5___ssd.adoc
@@ -124,12 +124,14 @@ The following XML child elements are specified for the Connector element:
 [width="100%",cols="23%,77%",options="header",]
 |===
 |Element |Description
-|Real / Integer / +
+|Real / Float64 / Float32 / +
+Integer / Int8 / UInt8 / Int16 / UInt16 / +
+Int32 / UInt32 / Int64 / UInt64 / +
 Boolean / String / Enumeration / Binary |Exactly one of these elements *CAN* be present to specify the type of the Connector. See 4.5.1 Type Choice for details.
 |ConnectorGeometry |This optional element defines the geometry information of the connector. See below for details.
 |===
 
-The type of the Connector is identified by the presence of one of the XML child elements Real, Integer, Boolean, String, Enumeration, or Binary.
+The type of the Connector is identified by the presence of one of the XML child elements Real, Float64, Float32, Integer, Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Boolean, String, Enumeration, or Binary.
 
 ===== ConnectorGeometry
 

--- a/docs/6___ssv.adoc
+++ b/docs/6___ssv.adoc
@@ -62,7 +62,10 @@ The following XML child elements are specified for the Parameter element:
 [width="100%",cols="31%,69%",options="header",]
 |===
 |Element |Description
-|Real / Integer / Boolean / String / Enumeration / Binary |Exactly one of these elements *MUST* be present to specify the type of the parameter. See below for details on each type.
+|Real / Float64 / Float32 / +
+Integer / Int8 / UInt8 / Int16 / UInt16 / +
+Int32 / UInt32 / Int64 / UInt64 / +
+Boolean / String / Enumeration / Binary |Exactly one of these elements *MUST* be present to specify the type of the parameter. See below for details on each type.
 |===
 
 ==== Real
@@ -78,11 +81,133 @@ This type specifies a parameter that represents an IEEE754 double precision floa
 |unit |This optional attribute gives the name of the unit of the parameter. The name *MUST* match the name of a unit defined in the Units element in the ParameterSet root element.
 |===
 
+==== Float64
+
+image:images/image50.png[image,width=231,height=149]
+
+This type specifies a parameter that represents an IEEE754 double precision floating point number.
+
+[width="100%",cols="23%,77%",options="header",]
+|===
+|Attribute |Description
+|value |This required attribute specifies the value of the parameter.
+|unit |This optional attribute gives the name of the unit of the parameter. The name *MUST* match the name of a unit defined in the Units element in the ParameterSet root element.
+|===
+
+==== Float32
+
+image:images/image50.png[image,width=231,height=149]
+
+This type specifies a parameter that represents an IEEE754 single precision floating point number.
+
+[width="100%",cols="23%,77%",options="header",]
+|===
+|Attribute |Description
+|value |This required attribute specifies the value of the parameter.
+|unit |This optional attribute gives the name of the unit of the parameter. The name *MUST* match the name of a unit defined in the Units element in the ParameterSet root element.
+|===
+
 ==== Integer
 
 image:images/image51.png[image,width=222,height=95]
 
 This type specifies a parameter that represents a 32-bit signed integer.
+
+[width="100%",cols="23%,77%",options="header",]
+|===
+|Attribute |Description
+|value |This required attribute specifies the value of the parameter.
+|===
+
+==== Int8
+
+image:images/image51.png[image,width=222,height=95]
+
+This type specifies a parameter that represents a 8-bit signed integer.
+
+[width="100%",cols="23%,77%",options="header",]
+|===
+|Attribute |Description
+|value |This required attribute specifies the value of the parameter.
+|===
+
+==== UInt8
+
+image:images/image51.png[image,width=222,height=95]
+
+This type specifies a parameter that represents a 8-bit unsigned integer.
+
+[width="100%",cols="23%,77%",options="header",]
+|===
+|Attribute |Description
+|value |This required attribute specifies the value of the parameter.
+|===
+
+==== Int16
+
+image:images/image51.png[image,width=222,height=95]
+
+This type specifies a parameter that represents a 16-bit signed integer.
+
+[width="100%",cols="23%,77%",options="header",]
+|===
+|Attribute |Description
+|value |This required attribute specifies the value of the parameter.
+|===
+
+==== UInt16
+
+image:images/image51.png[image,width=222,height=95]
+
+This type specifies a parameter that represents a 16-bit unsigned integer.
+
+[width="100%",cols="23%,77%",options="header",]
+|===
+|Attribute |Description
+|value |This required attribute specifies the value of the parameter.
+|===
+
+==== Int32
+
+image:images/image51.png[image,width=222,height=95]
+
+This type specifies a parameter that represents a 32-bit signed integer.
+
+[width="100%",cols="23%,77%",options="header",]
+|===
+|Attribute |Description
+|value |This required attribute specifies the value of the parameter.
+|===
+
+==== UInt32
+
+image:images/image51.png[image,width=222,height=95]
+
+This type specifies a parameter that represents a 32-bit unsigned integer.
+
+[width="100%",cols="23%,77%",options="header",]
+|===
+|Attribute |Description
+|value |This required attribute specifies the value of the parameter.
+|===
+
+==== Int64
+
+image:images/image51.png[image,width=222,height=95]
+
+This type specifies a parameter that represents a 64-bit signed integer.
+
+[width="100%",cols="23%,77%",options="header",]
+|===
+|Attribute |Description
+|value |This required attribute specifies the value of the parameter.
+|===
+
+==== UInt64
+
+image:images/image51.png[image,width=222,height=95]
+
+This type specifies a parameter that represents a 64-bit unsigned integer.
 
 [width="100%",cols="23%,77%",options="header",]
 |===

--- a/docs/8___ssb.adoc
+++ b/docs/8___ssb.adoc
@@ -53,6 +53,8 @@ The following XML child elements are specified for the DictionaryEntry element:
 [width="100%",cols="33%,67%",options="header",]
 |===
 |Element |Description
-|Real / Integer / +
+|Real / Float64 / Float32 / +
+Integer / Int8 / UInt8 / Int16 / UInt16 / +
+Int32 / UInt32 / Int64 / UInt64 / +
 Boolean / String / Enumeration / Binary |Exactly one of these elements *MUST* be present to specify the type of the signal dictionary entry. See section 4.5.1 for details.
 |===

--- a/schema/SystemStructureCommon.xsd
+++ b/schema/SystemStructureCommon.xsd
@@ -116,6 +116,13 @@
         </xs:attribute>
     </xs:attributeGroup>
     
+    <xs:simpleType name="TGenericInteger">
+        <xs:restriction base="xs:integer">
+            <xs:maxInclusive value="18446744073709551615"/>
+            <xs:minInclusive value="-9223372036854775808"/>
+        </xs:restriction>
+    </xs:simpleType>
+    
     <xs:complexType name="TEnumerations">
         <xs:sequence>
             <xs:element name="Enumeration" minOccurs="1" maxOccurs="unbounded" type="ssc:TEnumeration"/>
@@ -481,7 +488,7 @@
                     <xs:documentation xml:lang="en">
                         This element provides for a transformation of integer parameter values
                         based on a mapping table and is valid for parameters of integer and 
-                        enumeration type.  Each mapping table entry is provided by a MapEntry
+                        enumeration types.  Each mapping table entry is provided by a MapEntry
                         element.
                     </xs:documentation>
                 </xs:annotation>
@@ -489,7 +496,7 @@
                     <xs:sequence>
                         <xs:element name="MapEntry" minOccurs="1" maxOccurs="unbounded">
                             <xs:complexType>
-                                <xs:attribute name="source" type="xs:int" use="required">
+                                <xs:attribute name="source" type="ssc:TGenericInteger" use="required">
                                     <xs:annotation>
                                         <xs:documentation xml:lang="en">
                                             This attribute gives the value of the parameter in the
@@ -497,7 +504,7 @@
                                         </xs:documentation>
                                     </xs:annotation>
                                 </xs:attribute>
-                                <xs:attribute name="target" type="xs:int" use="required">
+                                <xs:attribute name="target" type="ssc:TGenericInteger" use="required">
                                     <xs:annotation>
                                         <xs:documentation xml:lang="en">
                                             This attribute gives the value of the parameter to use

--- a/schema/SystemStructureCommon.xsd
+++ b/schema/SystemStructureCommon.xsd
@@ -276,7 +276,79 @@
                     </xs:attribute>
                 </xs:complexType>
             </xs:element>
+            <xs:element name="Float64">
+                <xs:complexType>
+                    <xs:attribute name="unit" type="xs:string" use="optional">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute gives the unit of the entity and must
+                                reference one of the unit definitions provided in the Units
+                                element of the containing file.
+                                
+                                If a unit is not supplied, the unit is determined through
+                                default mechanisms: For FMU components, the unit of the
+                                underlying variable would be used, for systems the units
+                                of connected underlying connectors could be used if unambiguous.
+                                If a unit cannot be deduced unambinguously, the user should
+                                be informed of this error.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Float32">
+                <xs:complexType>
+                    <xs:attribute name="unit" type="xs:string" use="optional">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute gives the unit of the entity and must
+                                reference one of the unit definitions provided in the Units
+                                element of the containing file.
+                                
+                                If a unit is not supplied, the unit is determined through
+                                default mechanisms: For FMU components, the unit of the
+                                underlying variable would be used, for systems the units
+                                of connected underlying connectors could be used if unambiguous.
+                                If a unit cannot be deduced unambinguously, the user should
+                                be informed of this error.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
             <xs:element name="Integer">
+                <xs:complexType>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Int8">
+                <xs:complexType>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="UInt8">
+                <xs:complexType>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Int16">
+                <xs:complexType>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="UInt16">
+                <xs:complexType>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Int32">
+                <xs:complexType>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="UInt32">
+                <xs:complexType>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Int64">
+                <xs:complexType>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="UInt64">
                 <xs:complexType>
                 </xs:complexType>
             </xs:element>

--- a/schema/SystemStructureCommon.xsd
+++ b/schema/SystemStructureCommon.xsd
@@ -487,7 +487,7 @@
                 <xs:annotation>
                     <xs:documentation xml:lang="en">
                         This element provides for a transformation of integer parameter values
-                        based on a mapping table and is valid for parameters of integer and 
+                        based on a mapping table and is valid for parameters of all integer and 
                         enumeration types.  Each mapping table entry is provided by a MapEntry
                         element.
                     </xs:documentation>

--- a/schema/SystemStructureParameterValues.xsd
+++ b/schema/SystemStructureParameterValues.xsd
@@ -105,9 +105,137 @@
                         </xs:attribute>
                     </xs:complexType>
                 </xs:element>
+                <xs:element name="Float64">
+                    <xs:complexType>
+                        <xs:attribute name="value" type="xs:double" use="required">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This attribute gives the value of the parameter.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="unit" type="xs:string" use="optional">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This attribute gives the unit of the parameter value and must
+                                    reference one of the unit definitions provided in the Units
+                                    element of the enclosing file.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="Float32">
+                    <xs:complexType>
+                        <xs:attribute name="value" type="xs:single" use="required">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This attribute gives the value of the parameter.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="unit" type="xs:string" use="optional">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This attribute gives the unit of the parameter value and must
+                                    reference one of the unit definitions provided in the Units
+                                    element of the enclosing file.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
                 <xs:element name="Integer">
                     <xs:complexType>
                         <xs:attribute name="value" type="xs:int" use="required">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This attribute gives the value of the parameter.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="Int8">
+                    <xs:complexType>
+                        <xs:attribute name="value" type="xs:byte" use="required">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This attribute gives the value of the parameter.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="UInt8">
+                    <xs:complexType>
+                        <xs:attribute name="value" type="xs:unsignedByte" use="required">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This attribute gives the value of the parameter.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="Int16">
+                    <xs:complexType>
+                        <xs:attribute name="value" type="xs:short" use="required">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This attribute gives the value of the parameter.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="UInt16">
+                    <xs:complexType>
+                        <xs:attribute name="value" type="xs:unsignedShort" use="required">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This attribute gives the value of the parameter.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="Int32">
+                    <xs:complexType>
+                        <xs:attribute name="value" type="xs:int" use="required">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This attribute gives the value of the parameter.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="UInt32">
+                    <xs:complexType>
+                        <xs:attribute name="value" type="xs:unsignedInt" use="required">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This attribute gives the value of the parameter.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="Int64">
+                    <xs:complexType>
+                        <xs:attribute name="value" type="xs:long" use="required">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This attribute gives the value of the parameter.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="UInt64">
+                    <xs:complexType>
+                        <xs:attribute name="value" type="xs:unsignedLong" use="required">
                             <xs:annotation>
                                 <xs:documentation xml:lang="en">
                                     This attribute gives the value of the parameter.


### PR DESCRIPTION
This currently handles all new data types except for clocks. It does not
handle arrays.