### PR TITLE
Allow mixed content in annotations, as in FMI 3.0

### DIFF
--- a/schema/SystemStructureCommon.xsd
+++ b/schema/SystemStructureCommon.xsd
@@ -228,7 +228,7 @@
     <xs:complexType name="TAnnotations">
         <xs:sequence maxOccurs="unbounded">
             <xs:element name="Annotation">
-                <xs:complexType>
+                <xs:complexType mixed="true">
                     <xs:sequence>
                         <xs:any namespace="##any" processContents="lax" minOccurs="0"/>
                     </xs:sequence>


### PR DESCRIPTION
Closes #12.