### PR TITLE
Add initial implementation of stimuli and references

### DIFF
--- a/schema/SystemStructureDescription.xsd
+++ b/schema/SystemStructureDescription.xsd
@@ -50,7 +50,7 @@
                 <xs:element name="System" type="ssd:TSystem"/>
                 <xs:element name="Enumerations" minOccurs="0" type="ssc:TEnumerations"/>
                 <xs:element name="Units" minOccurs="0" type="ssc:TUnits"/>
-                <xs:element name="DefaultExperiment" minOccurs="0" type="ssd:TDefaultExperiment"/>
+                <xs:element name="DefaultExperiment" minOccurs="0" maxOccurs="unbounded" type="ssd:TDefaultExperiment"/>
                 <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
             </xs:sequence>
             <xs:attribute name="version" use="required">
@@ -941,6 +941,8 @@
             </xs:documentation>
         </xs:annotation>
         <xs:sequence>
+            <xs:element name="Stimuli" minOccurs="0" type="ssd:TTimeSeriesBindings"/>
+            <xs:element name="References" minOccurs="0" type="ssd:TTimeSeriesBindings"/>
             <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
         </xs:sequence>
         <xs:attribute name="startTime" type="xs:double" use="optional">
@@ -951,7 +953,146 @@
         <xs:attribute name="stopTime" type="xs:double" use="optional">
             <xs:annotation>
                 <xs:documentation xml:lang="en">Default stop time of simulation</xs:documentation>
-            </xs:annotation>            
+            </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="tolerance" type="xs:double" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">Default tolerance of simulation</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="stepSize" type="xs:double" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">Default step size of simulation</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="TTimeSeriesBindings">
+        <xs:sequence maxOccurs="unbounded">
+            <xs:element name="TimeSeriesBinding">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        This provides time series data for the overall system, either as a source of
+                        stimuli, or as a source of reference outputs.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="TimeSeriesValues" minOccurs="0">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This optional element can be used to provide time series values inline
+                                    to the time series binding, in which case the source attribute of the
+                                    binding element must be empty.
+                                    
+                                    The contents must be CSV according to the rules set out in XXX, if the
+                                    type attribute of the binding element is text/csv, or any other valid
+                                    mixed XML content if the type attribute references another MIME type
+                                    (in that case there should be a layered specification that defines how
+                                    embedding the content works for that MIME type).
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType mixed="true">
+                                <xs:choice>
+                                    <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+                                </xs:choice>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="TimeSeriesMapping" minOccurs="0">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This element provides an optional time series mapping, which specifies how
+                                    the variable names and values provided in the time series source are to be
+                                    mapped to the input/output connectors of the system in question.  If no
+                                    mapping is supplied, the variables names of the time series source are used
+                                    as is for name matching against the names of connectors in the system and
+                                    the values of the time series source are not transformed further before
+                                    being applied.
+                                    
+                                    The contents of the element can be used to provide a time series mapping
+                                    inline, in which case the source attribute of the TimeSeriesMapping element
+                                    must be empty.
+                                    
+                                    The contents must be an ssm:ParameterMapping element, if the type attribute
+                                    of this element is application/x-ssp-parameter-mapping, or any other valid
+                                    XML content if the type attribute references another MIME type (in that case
+                                    there should be a layered specification that defines how embedding the content
+                                    works for that MIME type).
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:choice>
+                                    <!-- NOTE: In XML Schema 1.1 this choice would also contain the following entry: 
+                                        
+                                         <xs:element ref="ssm:ParameterMapping"/>
+                                        
+                                         which specifies the proper way to directly embed a ParameterMapping inline.
+                                         Due to restrictions in XML Schema 1.0, this would lead to a violation of the
+                                         unique particle attribution schema component constraint, since the embedded
+                                         ssm:ParameterMapping element would also be matched by the more generic xs:any
+                                         specification.  Since XML Schema 1.1 validators are still rare compared with
+                                         1.0 validators, the default schema files for SSP are still restricted to 1.0;
+                                         however if you have access to a 1.1 validator/validating parser, you can
+                                         use the 1.1 variant of these stylesheets instead.
+                                    -->
+                                    <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+                                </xs:choice>
+                                <xs:attributeGroup ref="ssc:ABaseElement"/>
+                                <xs:attribute name="type" type="xs:string" use="optional" default="application/x-ssp-parameter-mapping"/>
+                                <xs:attribute name="source" type="xs:anyURI" use="optional">
+                                    <xs:annotation>
+                                        <xs:documentation xml:lang="en">
+                                            This attribute indicates the source of the time series mapping as a URI
+                                            (cf. RFC 3986).  For purposes of the resolution of relative URIs
+                                            the base URI is the URI of the SSD.
+                                            
+                                            If the source attribute is missing, the time series mapping is provided
+                                            inline as contents of the TimeSeriesMapping element, which must be
+                                            empty otherwise.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
+                    </xs:sequence>
+                    <xs:attributeGroup ref="ssc:ABaseElement"/>
+                    <xs:attribute name="type" type="xs:string" use="optional" default="text/csv">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute specifies the MIME type of the time series data source, which
+                                defaults to text/csv to indicate the CSV file format as specified in XXX.
+                                No further types are currently defined, but can of course be added at a later
+                                date, e.g. for pre-existing time series file formats, like HDF5, MDF, etc.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="source" type="xs:anyURI" use="optional">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute indicates the source of the time series data as a URI
+                                (cf. RFC 3986).  For purposes of the resolution of relative URIs
+                                the base URI is the URI of the SSD.
+                                
+                                If the source attribute is missing, the time series data is provided
+                                inline as contents of a TimeSeriesValues element, which must not be
+                                present otherwise.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="prefix" type="xs:string" use="optional" default="">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                Defines the optional prefix for name resolution and mapping purposes
+                                for this binding.  If this attribute is empty or not supplied no
+                                prefix is used for name resolution and mapping, otherwise the specified
+                                prefix is prepended to all names in the time series source prior to
+                                processing the normal name resolution or name mapping rules.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
     </xs:complexType>
 </xs:schema>

--- a/schema/SystemStructureDescription11.xsd
+++ b/schema/SystemStructureDescription11.xsd
@@ -59,7 +59,7 @@
                 <xs:element name="System" type="ssd:TSystem"/>
                 <xs:element name="Enumerations" minOccurs="0" type="ssc:TEnumerations"/>
                 <xs:element name="Units" minOccurs="0" type="ssc:TUnits"/>
-                <xs:element name="DefaultExperiment" minOccurs="0" type="ssd:TDefaultExperiment"/>
+                <xs:element name="DefaultExperiment" minOccurs="0" maxOccurs="unbounded" type="ssd:TDefaultExperiment"/>
                 <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
             </xs:sequence>
             <xs:attribute name="version" use="required">
@@ -914,6 +914,8 @@
             </xs:documentation>
         </xs:annotation>
         <xs:sequence>
+            <xs:element name="Stimuli" minOccurs="0" type="ssd:TTimeSeriesBindings"/>
+            <xs:element name="References" minOccurs="0" type="ssd:TTimeSeriesBindings"/>
             <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
         </xs:sequence>
         <xs:attribute name="startTime" type="xs:double" use="optional">
@@ -924,7 +926,134 @@
         <xs:attribute name="stopTime" type="xs:double" use="optional">
             <xs:annotation>
                 <xs:documentation xml:lang="en">Default stop time of simulation</xs:documentation>
-            </xs:annotation>            
+            </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="tolerance" type="xs:double" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">Default tolerance of simulation</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="stepSize" type="xs:double" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">Default step size of simulation</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="TTimeSeriesBindings">
+        <xs:sequence maxOccurs="unbounded">
+            <xs:element name="TimeSeriesBinding">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        This provides time series data for the overall system, either as a source of
+                        stimuli, or as a source of reference outputs.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="TimeSeriesValues" minOccurs="0">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This optional element can be used to provide time series values inline
+                                    to the time series binding, in which case the source attribute of the
+                                    binding element must be empty.
+                                    
+                                    The contents must be CSV according to the rules set out in XXX, if the
+                                    type attribute of the binding element is text/csv, or any other valid
+                                    mixed XML content if the type attribute references another MIME type
+                                    (in that case there should be a layered specification that defines how
+                                    embedding the content works for that MIME type).
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType mixed="true">
+                                <xs:choice>
+                                    <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+                                </xs:choice>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="TimeSeriesMapping" minOccurs="0">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This element provides an optional time series mapping, which specifies how
+                                    the variable names and values provided in the time series source are to be
+                                    mapped to the input/output connectors of the system in question.  If no
+                                    mapping is supplied, the variables names of the time series source are used
+                                    as is for name matching against the names of connectors in the system and
+                                    the values of the time series source are not transformed further before
+                                    being applied.
+                                    
+                                    The contents of the element can be used to provide a time series mapping
+                                    inline, in which case the source attribute of the TimeSeriesMapping element
+                                    must be empty.
+                                    
+                                    The contents must be an ssm:ParameterMapping element, if the type attribute
+                                    of this element is application/x-ssp-parameter-mapping, or any other valid
+                                    XML content if the type attribute references another MIME type (in that case
+                                    there should be a layered specification that defines how embedding the content
+                                    works for that MIME type).
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:choice>
+                                    <xs:element ref="ssm:ParameterMapping"/>
+                                    <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+                                </xs:choice>
+                                <xs:attributeGroup ref="ssc:ABaseElement"/>
+                                <xs:attribute name="type" type="xs:string" use="optional" default="application/x-ssp-parameter-mapping"/>
+                                <xs:attribute name="source" type="xs:anyURI" use="optional">
+                                    <xs:annotation>
+                                        <xs:documentation xml:lang="en">
+                                            This attribute indicates the source of the time series mapping as a URI
+                                            (cf. RFC 3986).  For purposes of the resolution of relative URIs
+                                            the base URI is the URI of the SSD.
+                                            
+                                            If the source attribute is missing, the time series mapping is provided
+                                            inline as contents of the TimeSeriesMapping element, which must be
+                                            empty otherwise.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
+                    </xs:sequence>
+                    <xs:attributeGroup ref="ssc:ABaseElement"/>
+                    <xs:attribute name="type" type="xs:string" use="optional" default="text/csv">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute specifies the MIME type of the time series data source, which
+                                defaults to text/csv to indicate the CSV file format as specified in XXX.
+                                No further types are currently defined, but can of course be added at a later
+                                date, e.g. for pre-existing time series file formats, like HDF5, MDF, etc.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="source" type="xs:anyURI" use="optional">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute indicates the source of the time series data as a URI
+                                (cf. RFC 3986).  For purposes of the resolution of relative URIs
+                                the base URI is the URI of the SSD.
+                                
+                                If the source attribute is missing, the time series data is provided
+                                inline as contents of a TimeSeriesValues element, which must not be
+                                present otherwise.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="prefix" type="xs:string" use="optional" default="">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                Defines the optional prefix for name resolution and mapping purposes
+                                for this binding.  If this attribute is empty or not supplied no
+                                prefix is used for name resolution and mapping, otherwise the specified
+                                prefix is prepended to all names in the time series source prior to
+                                processing the normal name resolution or name mapping rules.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
     </xs:complexType>
 </xs:schema>


### PR DESCRIPTION
This provides a first draft of how stimuli and references could be provided for an SSD system, as part of one or more DefaultExperiment elements.

Further refinement and documentation is needed, this should serve as a discussion starter.