### PR TITLE
Add SRMD support

### DIFF
--- a/schema/SystemStructureCommon.xsd
+++ b/schema/SystemStructureCommon.xsd
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
-    xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
-    targetNamespace="http://ssp-standard.org/SSP1/SystemStructureCommon">
-    <xs:annotation>
-        <xs:documentation xml:lang="en">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:xlink="http://www.w3.org/1999/xlink" targetNamespace="http://ssp-standard.org/SSP1/SystemStructureCommon" elementFormDefault="qualified">
+	<xs:import namespace="http://www.w3.org/1999/xlink" schemaLocation="https://www.w3.org/XML/2008/06/xlink.xsd"/>
+	<xs:annotation>
+		<xs:documentation xml:lang="en">
             This is the normative XML Schema 1.0 schema for the MAP SSP
             SystemStructure 2.0 common content across formats.
             
@@ -39,202 +38,288 @@
             OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
             POSSIBILITY OF SUCH DAMAGE.
         </xs:documentation>
-    </xs:annotation>
-    
-    <xs:attributeGroup name="ABaseElement">
-        <xs:annotation>
-            <xs:documentation xml:lang="en">
+	</xs:annotation>
+	<xs:attributeGroup name="ABaseElement">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">
                 This attribute group specifies the attributes common to all model elements.
             </xs:documentation>
-        </xs:annotation>
-        <xs:attribute name="id" type="xs:ID" use="optional">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
+		</xs:annotation>
+		<xs:attribute name="id" type="xs:ID" use="optional">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
                     This attribute gives the model element a file-wide unique id which can
                     be referenced from other elements or via URI fragment identifier.
                 </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="description" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="description" type="xs:string" use="optional">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
                     This attribute gives a human readable longer description of the
                     model element, which can be shown to the user where appropriate. 
                 </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:attributeGroup>
-    
-    <xs:attributeGroup name="ATopLevelMetaData">
-        <xs:annotation>
-            <xs:documentation xml:lang="en">
+			</xs:annotation>
+		</xs:attribute>
+	</xs:attributeGroup>
+	<xs:group name="GElementCommon">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">
+                Common element content for all modeling elements of the STC file.
+            </xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Classification" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">
+                        This element, which can occur multiple times, provides a set of classifications
+                        of an STC modeling element, provided as Keyword Value Pairs (KWP), the meaning
+                        of which is interpreted according to the name of the classification provided in
+                        the name attribute.
+                        
+                        This approach can be used, for example, to provide searchable keywords for
+                        content, or to assign and track quality or validation level requirements
+                        across the STC process, or to maintain variant or other classification
+                        content across the process.
+                    </xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="ClassificationEntry" minOccurs="0" maxOccurs="unbounded">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">
+                                    This element provides a keyword value pair entry, with the
+                                    keyword provided through the keyword attribute and the value
+                                    being the contents of the element.
+                                </xs:documentation>
+							</xs:annotation>
+							<xs:complexType mixed="true">
+								<xs:sequence>
+									<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+								</xs:sequence>
+								<xs:attribute name="keyword" type="xs:normalizedString" use="required">
+									<xs:annotation>
+										<xs:documentation xml:lang="en">
+                                            This attribute gives the keyword for the classification entry
+                                            (i.e. keyword value pair).  It is left undefined whether this
+                                            must be unique across the entries of the Classification element,
+                                            or whether repeated entries are allowed.  This will depend on
+                                            the definition of the classification.
+                                        </xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+								<xs:attribute ref="xlink:type" fixed="simple"/>
+								<xs:attribute ref="xlink:href">
+									<xs:annotation>
+										<xs:documentation xml:lang="en">
+                                            This attribute gives an optional link for the classification
+                                            entry (i.e. keyword value pair).  This link can be given in
+                                            addition to any content of the classification entry, or it
+                                            can be the sole information of the classification entry.
+                                            The rules will depend on the definition of the classification.
+                                        </xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+								<xs:attributeGroup ref="ssc:ABaseElement"/>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="type" type="xs:normalizedString">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
+                                This attribute provides the name of the type of classification
+                                being provided.  The name should be unique across the Classification
+                                elements of the immediately enclosing element.
+                                
+                                In order to ensure uniqueness all types should be identified
+                                with reverse domain name notation (cf. Java package names
+                                or Apple UTIs) of a domain that is controlled by the entity
+                                defining the semantics and content of the classification.
+                            </xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute ref="xlink:type" fixed="simple"/>
+					<xs:attribute ref="xlink:href">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
+                                This attribute gives an optional link for the classification
+                                itself.  This link can be given to provide additional,
+                                potentially human readable information on the classification
+                                type that tools can use to provide this information to the
+                                user, especially for unknown classification types.
+                            </xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attributeGroup ref="ssc:ABaseElement"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Annotations" type="ssc:TAnnotations" minOccurs="0"/>
+		</xs:sequence>
+	</xs:group>
+	<xs:attributeGroup name="ATopLevelMetaData">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">
                 This attribute group specifies the optional meta-data attributes common to 
                 all top-level container elements of all defined file formats.
             </xs:documentation>
-        </xs:annotation>
-        <xs:attribute name="author" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
+		</xs:annotation>
+		<xs:attribute name="author" type="xs:string" use="optional">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
                     This attribute gives the name of the author of this file's content. 
                 </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="fileversion" type="xs:normalizedString" use="optional">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="fileversion" type="xs:normalizedString" use="optional">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
                     This attribute gives a version number for this file's content. 
                 </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="copyright" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="copyright" type="xs:string" use="optional">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
                     This attribute gives copyright information for this file's content. 
                 </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="license" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="license" type="xs:string" use="optional">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
                     This attribute gives license information for this file's content. 
                 </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="generationTool" type="xs:normalizedString">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="generationTool" type="xs:normalizedString">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
                     This attribute gives the name of the tool that generated this file. 
                 </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="generationDateAndTime" type="xs:dateTime">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="generationDateAndTime" type="xs:dateTime">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
                     This attribute gives the date and time this file was generated. 
                 </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:attributeGroup>
-    
-    <xs:simpleType name="TGenericInteger">
-        <xs:restriction base="xs:integer">
-            <xs:maxInclusive value="18446744073709551615"/>
-            <xs:minInclusive value="-9223372036854775808"/>
-        </xs:restriction>
-    </xs:simpleType>
-    
-    <xs:complexType name="TEnumerations">
-        <xs:sequence>
-            <xs:element name="Enumeration" minOccurs="1" maxOccurs="unbounded" type="ssc:TEnumeration"/>
-        </xs:sequence>
-    </xs:complexType>
-    
-    <xs:complexType name="TEnumeration">
-        <xs:sequence>
-            <xs:element name="Item" minOccurs="1" maxOccurs="unbounded">
-                <xs:complexType>
-                    <xs:attribute name="name" type="xs:string" use="required">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">Name of the Enumeration Item</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="value" type="xs:int" use="required">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">The Value of the Enumeration Item</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
-        </xs:sequence>
-        <xs:attributeGroup ref="ssc:ABaseElement"/>
-        <xs:attribute name="name" type="xs:string" use="required">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
+			</xs:annotation>
+		</xs:attribute>
+	</xs:attributeGroup>
+	<xs:simpleType name="TGenericInteger">
+		<xs:restriction base="xs:integer">
+			<xs:maxInclusive value="18446744073709551615"/>
+			<xs:minInclusive value="-9223372036854775808"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="TEnumerations">
+		<xs:sequence>
+			<xs:element name="Enumeration" type="ssc:TEnumeration" minOccurs="1" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TEnumeration">
+		<xs:sequence>
+			<xs:element name="Item" minOccurs="1" maxOccurs="unbounded">
+				<xs:complexType>
+					<xs:attribute name="name" type="xs:string" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">Name of the Enumeration Item</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="value" type="xs:int" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">The Value of the Enumeration Item</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:group ref="ssc:GElementCommon"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ssc:ABaseElement"/>
+		<xs:attribute name="name" type="xs:string" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
                     This attribute specifies the name of the enumeration in the system description,
                     which must be unique within in the system description.
                 </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:complexType>
-    
-    <xs:complexType name="TUnits">
-        <xs:sequence>
-            <xs:element name="Unit" minOccurs="1" maxOccurs="unbounded" type="ssc:TUnit"/>
-        </xs:sequence>
-    </xs:complexType>
-    
-    <xs:complexType name="TUnit">
-        <xs:sequence>
-            <xs:element name="BaseUnit">
-                <xs:complexType>
-                    <xs:attribute name="kg" type="xs:int" default="0">
-                        <xs:annotation>
-                            <xs:documentation>Exponent of SI base unit "kg"</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="m" type="xs:int" default="0">
-                        <xs:annotation>
-                            <xs:documentation>Exponent of SI base unit "m"</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="s" type="xs:int" default="0">
-                        <xs:annotation>
-                            <xs:documentation>Exponent of SI base unit "s"</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="A" type="xs:int" default="0">
-                        <xs:annotation>
-                            <xs:documentation>Exponent of SI base unit "A"</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="K" type="xs:int" default="0">
-                        <xs:annotation>
-                            <xs:documentation>Exponent of SI base unit "K"</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="mol" type="xs:int" default="0">
-                        <xs:annotation>
-                            <xs:documentation>Exponent of SI base unit "mol"</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="cd" type="xs:int" default="0">
-                        <xs:annotation>
-                            <xs:documentation>Exponent of SI base unit "cd"</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="rad" type="xs:int" default="0">
-                        <xs:annotation>
-                            <xs:documentation>Exponent of SI derived unit "rad"</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="factor" type="xs:double" default="1"/>
-                    <xs:attribute name="offset" type="xs:double" default="0"/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
-        </xs:sequence>
-        <xs:attributeGroup ref="ssc:ABaseElement"/>
-        <xs:attribute name="name" type="xs:string" use="required">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="TUnits">
+		<xs:sequence>
+			<xs:element name="Unit" type="ssc:TUnit" minOccurs="1" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TUnit">
+		<xs:sequence>
+			<xs:element name="BaseUnit">
+				<xs:complexType>
+					<xs:attribute name="kg" type="xs:int" default="0">
+						<xs:annotation>
+							<xs:documentation>Exponent of SI base unit "kg"</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="m" type="xs:int" default="0">
+						<xs:annotation>
+							<xs:documentation>Exponent of SI base unit "m"</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="s" type="xs:int" default="0">
+						<xs:annotation>
+							<xs:documentation>Exponent of SI base unit "s"</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="A" type="xs:int" default="0">
+						<xs:annotation>
+							<xs:documentation>Exponent of SI base unit "A"</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="K" type="xs:int" default="0">
+						<xs:annotation>
+							<xs:documentation>Exponent of SI base unit "K"</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="mol" type="xs:int" default="0">
+						<xs:annotation>
+							<xs:documentation>Exponent of SI base unit "mol"</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="cd" type="xs:int" default="0">
+						<xs:annotation>
+							<xs:documentation>Exponent of SI base unit "cd"</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="rad" type="xs:int" default="0">
+						<xs:annotation>
+							<xs:documentation>Exponent of SI derived unit "rad"</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="factor" type="xs:double" default="1"/>
+					<xs:attribute name="offset" type="xs:double" default="0"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:group ref="ssc:GElementCommon"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ssc:ABaseElement"/>
+		<xs:attribute name="name" type="xs:string" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
                     This attribute specifies the name of the unit in the system description,
                     which must be unique within in the system description.
                 </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:complexType>
-    
-    <xs:complexType name="TAnnotations">
-        <xs:sequence maxOccurs="unbounded">
-            <xs:element name="Annotation">
-                <xs:complexType mixed="true">
-                    <xs:sequence>
-                        <xs:any namespace="##any" processContents="lax" minOccurs="0"/>
-                    </xs:sequence>
-                    <xs:attribute name="type" type="xs:normalizedString" use="required">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="TAnnotations">
+		<xs:sequence maxOccurs="unbounded">
+			<xs:element name="Annotation">
+				<xs:complexType mixed="true">
+					<xs:sequence>
+						<xs:any namespace="##any" processContents="lax" minOccurs="0"/>
+					</xs:sequence>
+					<xs:attribute name="type" type="xs:normalizedString" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
                                 The unique name of the type of the annotation.
                                 
                                 In order to ensure uniqueness all types should be identified
@@ -248,26 +333,25 @@
                                 For MAP-SSP defined annotations, this will be a domain under
                                 the org.modelica prefix.
                             </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:complexType>
-            </xs:element>
-        </xs:sequence>
-    </xs:complexType>
-    
-    <xs:group name="GTypeChoice">
-        <xs:choice>
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:group name="GTypeChoice">
+		<xs:choice>
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
                     This element gives the type of a connector or signal dictionary entry
                     (called entity below).
                 </xs:documentation>
-            </xs:annotation>
-            <xs:element name="Real">
-                <xs:complexType>
-                    <xs:attribute name="unit" type="xs:string" use="optional">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
+			</xs:annotation>
+			<xs:element name="Real">
+				<xs:complexType>
+					<xs:attribute name="unit" type="xs:string" use="optional">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
                                 This attribute gives the unit of the entity and must
                                 reference one of the unit definitions provided in the Units
                                 element of the containing file.
@@ -279,15 +363,15 @@
                                 If a unit cannot be deduced unambinguously, the user should
                                 be informed of this error.
                             </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="Float64">
-                <xs:complexType>
-                    <xs:attribute name="unit" type="xs:string" use="optional">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Float64">
+				<xs:complexType>
+					<xs:attribute name="unit" type="xs:string" use="optional">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
                                 This attribute gives the unit of the entity and must
                                 reference one of the unit definitions provided in the Units
                                 element of the containing file.
@@ -299,15 +383,15 @@
                                 If a unit cannot be deduced unambinguously, the user should
                                 be informed of this error.
                             </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="Float32">
-                <xs:complexType>
-                    <xs:attribute name="unit" type="xs:string" use="optional">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Float32">
+				<xs:complexType>
+					<xs:attribute name="unit" type="xs:string" use="optional">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
                                 This attribute gives the unit of the entity and must
                                 reference one of the unit definitions provided in the Units
                                 element of the containing file.
@@ -319,73 +403,62 @@
                                 If a unit cannot be deduced unambinguously, the user should
                                 be informed of this error.
                             </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="Integer">
-                <xs:complexType>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="Int8">
-                <xs:complexType>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="UInt8">
-                <xs:complexType>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="Int16">
-                <xs:complexType>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="UInt16">
-                <xs:complexType>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="Int32">
-                <xs:complexType>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="UInt32">
-                <xs:complexType>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="Int64">
-                <xs:complexType>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="UInt64">
-                <xs:complexType>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="Boolean">
-                <xs:complexType>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="String">
-                <xs:complexType>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="Enumeration">
-                <xs:complexType>
-                    <xs:attribute name="name" type="xs:string" use="required">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Integer">
+				<xs:complexType/>
+			</xs:element>
+			<xs:element name="Int8">
+				<xs:complexType/>
+			</xs:element>
+			<xs:element name="UInt8">
+				<xs:complexType/>
+			</xs:element>
+			<xs:element name="Int16">
+				<xs:complexType/>
+			</xs:element>
+			<xs:element name="UInt16">
+				<xs:complexType/>
+			</xs:element>
+			<xs:element name="Int32">
+				<xs:complexType/>
+			</xs:element>
+			<xs:element name="UInt32">
+				<xs:complexType/>
+			</xs:element>
+			<xs:element name="Int64">
+				<xs:complexType/>
+			</xs:element>
+			<xs:element name="UInt64">
+				<xs:complexType/>
+			</xs:element>
+			<xs:element name="Boolean">
+				<xs:complexType/>
+			</xs:element>
+			<xs:element name="String">
+				<xs:complexType/>
+			</xs:element>
+			<xs:element name="Enumeration">
+				<xs:complexType>
+					<xs:attribute name="name" type="xs:string" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
                                 This attribute specifies the name of the enumeration
                                 which references into the set of defined enumerations
                                 of the system structure description, as contained in
                                 the Enumerations element of the root element.
                             </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="Binary">
-                <xs:complexType>
-                    <xs:attribute name="mime-type" type="xs:string" default="application/octet-stream">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Binary">
+				<xs:complexType>
+					<xs:attribute name="mime-type" type="xs:string" default="application/octet-stream">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
                                 This optional attribute specifies the MIME type of the
                                 underlying binary data, which defaults to the non-specific
                                 application/octet-stream type.  This information can be
@@ -396,32 +469,31 @@
                                 service, i.e. it remains the responsibility of the operator 
                                 to ensure only compatible binary connectors are connected.
                             </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:complexType>
-            </xs:element>
-        </xs:choice>
-    </xs:group>
-    
-    <xs:group name="GTransformationChoice">
-        <xs:annotation>
-            <xs:documentation xml:lang="en">
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+		</xs:choice>
+	</xs:group>
+	<xs:group name="GTransformationChoice">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">
                 This element specifies the transformation to be applied to a value prior to its
                 use in a connection or parameter mapping.
             </xs:documentation>
-        </xs:annotation>
-        <xs:choice>
-            <xs:element name="LinearTransformation">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
+		</xs:annotation>
+		<xs:choice>
+			<xs:element name="LinearTransformation">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">
                         This element provides for a linear transformation to be performed on the
                         parameter values and is valid for parameters of a continuous type.
                     </xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:attribute name="factor" type="xs:double" use="optional" default="1.0">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
+				</xs:annotation>
+				<xs:complexType>
+					<xs:attribute name="factor" type="xs:double" use="optional" default="1.0">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
                                 This attribute specifies an optional factor value to use in a linear
                                 transformation of the source parameter value to the target parameter
                                 value, i.e. in the calculation target = factor * source + offset.
@@ -431,11 +503,11 @@
                                 linear transformation, i.e. the value of source is already converted
                                 to the target unit in the formula above.
                             </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="offset" type="xs:double" use="optional" default="0.0">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="offset" type="xs:double" use="optional" default="0.0">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
                                 This attribute specifies an optional offset value to use in a linear
                                 transformation of the source parameter value to the target parameter
                                 value, i.e. in the calculation target = factor * source + offset.
@@ -445,115 +517,114 @@
                                 linear transformation, i.e. the value of source is already converted
                                 to the target unit in the formula above.
                             </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="BooleanMappingTransformation">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="BooleanMappingTransformation">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">
                         This element provides for a transformation of boolean parameter values
                         based on a mapping table and is valid for parameters of boolean type.
                         Each mapping table entry is provided by a MapEntry element.
                     </xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element name="MapEntry" minOccurs="1" maxOccurs="unbounded">
-                            <xs:complexType>
-                                <xs:attribute name="source" type="xs:boolean" use="required">
-                                    <xs:annotation>
-                                        <xs:documentation xml:lang="en">
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="MapEntry" minOccurs="1" maxOccurs="unbounded">
+							<xs:complexType>
+								<xs:attribute name="source" type="xs:boolean" use="required">
+									<xs:annotation>
+										<xs:documentation xml:lang="en">
                                             This attribute gives the value of the parameter in the
                                             parameter source that this entry applies to.
                                         </xs:documentation>
-                                    </xs:annotation>
-                                </xs:attribute>
-                                <xs:attribute name="target" type="xs:boolean" use="required">
-                                    <xs:annotation>
-                                        <xs:documentation xml:lang="en">
+									</xs:annotation>
+								</xs:attribute>
+								<xs:attribute name="target" type="xs:boolean" use="required">
+									<xs:annotation>
+										<xs:documentation xml:lang="en">
                                             This attribute gives the value of the parameter to use
                                             when applying it to the system or component that is to be
                                             parametrized.
                                         </xs:documentation>
-                                    </xs:annotation>
-                                </xs:attribute>
-                            </xs:complexType>
-                        </xs:element>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="IntegerMappingTransformation">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
+									</xs:annotation>
+								</xs:attribute>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="IntegerMappingTransformation">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">
                         This element provides for a transformation of integer parameter values
                         based on a mapping table and is valid for parameters of all integer and 
                         enumeration types.  Each mapping table entry is provided by a MapEntry
                         element.
                     </xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element name="MapEntry" minOccurs="1" maxOccurs="unbounded">
-                            <xs:complexType>
-                                <xs:attribute name="source" type="ssc:TGenericInteger" use="required">
-                                    <xs:annotation>
-                                        <xs:documentation xml:lang="en">
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="MapEntry" minOccurs="1" maxOccurs="unbounded">
+							<xs:complexType>
+								<xs:attribute name="source" type="ssc:TGenericInteger" use="required">
+									<xs:annotation>
+										<xs:documentation xml:lang="en">
                                             This attribute gives the value of the parameter in the
                                             parameter source that this entry applies to.
                                         </xs:documentation>
-                                    </xs:annotation>
-                                </xs:attribute>
-                                <xs:attribute name="target" type="ssc:TGenericInteger" use="required">
-                                    <xs:annotation>
-                                        <xs:documentation xml:lang="en">
+									</xs:annotation>
+								</xs:attribute>
+								<xs:attribute name="target" type="ssc:TGenericInteger" use="required">
+									<xs:annotation>
+										<xs:documentation xml:lang="en">
                                             This attribute gives the value of the parameter to use
                                             when applying it to the system or component that is to be
                                             parametrized.
                                         </xs:documentation>
-                                    </xs:annotation>
-                                </xs:attribute>
-                            </xs:complexType>
-                        </xs:element>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="EnumerationMappingTransformation">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
+									</xs:annotation>
+								</xs:attribute>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="EnumerationMappingTransformation">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">
                         This element provides for a transformation of enumeration parameter values
                         based on a mapping table of their enumeration item names and is valid for
                         parameters of enumeration type.  Each mapping table entry is provided by a
                         MapEntry element.
                     </xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element name="MapEntry" minOccurs="1" maxOccurs="unbounded">
-                            <xs:complexType>
-                                <xs:attribute name="source" type="xs:string" use="required">
-                                    <xs:annotation>
-                                        <xs:documentation xml:lang="en">
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="MapEntry" minOccurs="1" maxOccurs="unbounded">
+							<xs:complexType>
+								<xs:attribute name="source" type="xs:string" use="required">
+									<xs:annotation>
+										<xs:documentation xml:lang="en">
                                             This attribute gives the value of the parameter in the
                                             parameter source that this entry applies to.
                                         </xs:documentation>
-                                    </xs:annotation>
-                                </xs:attribute>
-                                <xs:attribute name="target" type="xs:string" use="required">
-                                    <xs:annotation>
-                                        <xs:documentation xml:lang="en">
+									</xs:annotation>
+								</xs:attribute>
+								<xs:attribute name="target" type="xs:string" use="required">
+									<xs:annotation>
+										<xs:documentation xml:lang="en">
                                             This attribute gives the value of the parameter to use
                                             when applying it to the system or component that is to be
                                             parametrized.
                                         </xs:documentation>
-                                    </xs:annotation>
-                                </xs:attribute>
-                            </xs:complexType>
-                        </xs:element>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-        </xs:choice>
-    </xs:group>
-    
+									</xs:annotation>
+								</xs:attribute>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:choice>
+	</xs:group>
 </xs:schema>

--- a/schema/SystemStructureDescription.xsd
+++ b/schema/SystemStructureDescription.xsd
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
-    xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
-    xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
-    targetNamespace="http://ssp-standard.org/SSP1/SystemStructureDescription">
-    <xs:annotation>
-        <xs:documentation xml:lang="en">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" targetNamespace="http://ssp-standard.org/SSP1/SystemStructureDescription" elementFormDefault="qualified">
+	<xs:annotation>
+		<xs:documentation xml:lang="en">
             This is the normative XML Schema 1.0 schema for the MAP SSP
             SystemStructureDescription 2.0 format.
             
@@ -40,55 +37,52 @@
             OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
             POSSIBILITY OF SUCH DAMAGE.
         </xs:documentation>
-    </xs:annotation>
-    
-    <xs:import namespace="http://ssp-standard.org/SSP1/SystemStructureCommon" schemaLocation="SystemStructureCommon.xsd"/>
-    
-    <xs:element name="SystemStructureDescription">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="System" type="ssd:TSystem"/>
-                <xs:element name="Enumerations" minOccurs="0" type="ssc:TEnumerations"/>
-                <xs:element name="Units" minOccurs="0" type="ssc:TUnits"/>
-                <xs:element name="DefaultExperiment" minOccurs="0" type="ssd:TDefaultExperiment"/>
-                <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
-            </xs:sequence>
-            <xs:attribute name="version" use="required">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
+	</xs:annotation>
+	<xs:import namespace="http://ssp-standard.org/SSP1/SystemStructureCommon" schemaLocation="SystemStructureCommon.xsd"/>
+	<xs:element name="SystemStructureDescription">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="System" type="ssd:TSystem"/>
+				<xs:element name="Enumerations" type="ssc:TEnumerations" minOccurs="0"/>
+				<xs:element name="Units" type="ssc:TUnits" minOccurs="0"/>
+				<xs:element name="DefaultExperiment" type="ssd:TDefaultExperiment" minOccurs="0"/>
+				<xs:group ref="ssc:GElementCommon"/>
+			</xs:sequence>
+			<xs:attribute name="version" use="required">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">
                         Version of SSD format, 2.0-alpha for this release.
                     </xs:documentation>
-                </xs:annotation>
-                <xs:simpleType>
-                    <xs:restriction base="xs:normalizedString">
-                        <xs:pattern value="2[.][0-9]+(-.+)"/>
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:attribute>
-            <xs:attribute name="name" type="xs:string" use="required">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:normalizedString">
+						<xs:pattern value="2[.][0-9]+(-.+)"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="name" type="xs:string" use="required">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">
                         This attribute gives the system structure a name, which can be used
                         for purposes of presenting the system structure to the user, e.g.
                         when selecting individual variant SSDs from an SSP.
                     </xs:documentation>
-                </xs:annotation>
-            </xs:attribute>
-            <xs:attributeGroup ref="ssc:ABaseElement"/>
-            <xs:attributeGroup ref="ssc:ATopLevelMetaData"/>
-        </xs:complexType>
-    </xs:element>
-        
-    <xs:complexType name="TElement">
-        <xs:annotation>
-            <xs:documentation xml:lang="en">
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attributeGroup ref="ssc:ABaseElement"/>
+			<xs:attributeGroup ref="ssc:ATopLevelMetaData"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="TElement">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">
                 This is the base type for all elements, currently consisting of components and systems.
             </xs:documentation>
-        </xs:annotation>
-        <xs:sequence>
-            <xs:element name="Connectors" minOccurs="0" type="ssd:TConnectors">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Connectors" type="ssd:TConnectors" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">
                         The set of connectors of this element, which represent
                         the interface of the element to the outside world.
  
@@ -102,11 +96,11 @@
                         be present which are referenced in connections inside
                         the SSD.
                     </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element name="ElementGeometry" minOccurs="0">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ElementGeometry" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">
                         This optional element defines the geometry information of the component.
                         (x1,y1) and (x2,y2) define the positions of the lower-left and upper-right
                         corners of the component in the coordinate system of the parent.
@@ -124,64 +118,61 @@
                         ratio. The optional attribute iconFlip defines whether any flipping indicated
                         by (x1,y1), (x2, y2) shall be applied to the icon graphics, too.
                     </xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:attribute name="x1" type="xs:double" use="required"/>
-                    <xs:attribute name="y1" type="xs:double" use="required"/>
-                    <xs:attribute name="x2" type="xs:double" use="required"/>
-                    <xs:attribute name="y2" type="xs:double" use="required"/>
-                    <xs:attribute name="rotation" type="xs:double" use="optional" default="0.0"/>
-                    <xs:attribute name="iconSource" type="xs:anyURI" use="optional"/>
-                    <xs:attribute name="iconRotation" type="xs:double" use="optional" default="0.0"/>
-                    <xs:attribute name="iconFlip" type="xs:boolean" use="optional" default="false"/>
-                    <xs:attribute name="iconFixedAspectRatio" type="xs:boolean" use="optional" default="false"/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="ParameterBindings" minOccurs="0" type="ssd:TParameterBindings">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
+				</xs:annotation>
+				<xs:complexType>
+					<xs:attribute name="x1" type="xs:double" use="required"/>
+					<xs:attribute name="y1" type="xs:double" use="required"/>
+					<xs:attribute name="x2" type="xs:double" use="required"/>
+					<xs:attribute name="y2" type="xs:double" use="required"/>
+					<xs:attribute name="rotation" type="xs:double" use="optional" default="0.0"/>
+					<xs:attribute name="iconSource" type="xs:anyURI" use="optional"/>
+					<xs:attribute name="iconRotation" type="xs:double" use="optional" default="0.0"/>
+					<xs:attribute name="iconFlip" type="xs:boolean" use="optional" default="false"/>
+					<xs:attribute name="iconFixedAspectRatio" type="xs:boolean" use="optional" default="false"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="ParameterBindings" type="ssd:TParameterBindings" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">
                         The set of parameter bindings for this element.
                     </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-        </xs:sequence>
-        <xs:attributeGroup ref="ssc:ABaseElement"/>
-        <xs:attribute name="name" use="required">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
+				</xs:annotation>
+			</xs:element>
+			<xs:group ref="ssc:GElementCommon"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ssc:ABaseElement"/>
+		<xs:attribute name="name" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
                     This attribute gives the element a name, which shall be unique
                     within the directly enclosing system. The name is used for
                     purposes of specifying the element's connectors in connections.
                 </xs:documentation>
-            </xs:annotation>
-            <xs:simpleType>
-                <xs:restriction base="xs:string">
-                    <xs:minLength value="1"/>
-                </xs:restriction>
-            </xs:simpleType>
-        </xs:attribute>
-    </xs:complexType>
-    
-    <xs:complexType name="TComponent">
-        <xs:complexContent>
-            <xs:extension base="ssd:TElement">
-                <xs:sequence>
-                    <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
-                </xs:sequence>
-                <xs:attribute name="type" type="xs:string" use="optional" default="application/x-fmu-sharedlibrary">
-                    <xs:annotation>
-                        <xs:documentation xml:lang="en">
+			</xs:annotation>
+			<xs:simpleType>
+				<xs:restriction base="xs:string">
+					<xs:minLength value="1"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="TComponent">
+		<xs:complexContent>
+			<xs:extension base="ssd:TElement">
+				<xs:attribute name="type" type="xs:string" use="optional" default="application/x-fmu-sharedlibrary">
+					<xs:annotation>
+						<xs:documentation xml:lang="en">
                             This attribute specifies the MIME type of the component, which defaults to
                             application/x-fmu-sharedlibrary to indicate an FMU.  When referencing another
                             system structure definition file, the MIME type application/x-ssp-definition
                             is used, and the MIME type application/x-ssp-package is used for referenced
                             system structure packages (SSPs). No further types are currently defined.
                         </xs:documentation>
-                    </xs:annotation>
-                </xs:attribute>
-                <xs:attribute name="source" type="xs:anyURI" use="required">
-                    <xs:annotation>
-                        <xs:documentation xml:lang="en">
+					</xs:annotation>
+				</xs:attribute>
+				<xs:attribute name="source" type="xs:anyURI" use="required">
+					<xs:annotation>
+						<xs:documentation xml:lang="en">
                             This attribute indicates the source of the component as an URI
                             (cf. RFC 3986).  For purposes of the resolution of relative URIs
                             the base URI is the URI of the SSD.  Therefore for components
@@ -217,11 +208,11 @@
                             support any absolute URIs and any specific URI schemes (but are of
                             course allowed to support any and all kinds of URIs where useful).
                         </xs:documentation>
-                    </xs:annotation>
-                </xs:attribute>
-                <xs:attribute name="implementation" use="optional" default="any">
-                    <xs:annotation>
-                        <xs:documentation xml:lang="en">
+					</xs:annotation>
+				</xs:attribute>
+				<xs:attribute name="implementation" use="optional" default="any">
+					<xs:annotation>
+						<xs:documentation xml:lang="en">
                             When the referenced component is an FMU that contains multiple
                             implementations (e.g. Co-Simulation and Model Exchange), this optional
                             attribute can be used to determine which FMU implementation should be
@@ -231,24 +222,23 @@
                             FMU implementation must be used.  It is an error if the specified type
                             of FMU implementation is not present in the FMU.
                         </xs:documentation>
-                    </xs:annotation>
-                    <xs:simpleType>
-                        <xs:restriction base="xs:string">
-                            <xs:enumeration value="any"/>
-                            <xs:enumeration value="ModelExchange"/>
-                            <xs:enumeration value="CoSimulation"/>
-                        </xs:restriction>
-                    </xs:simpleType>
-                </xs:attribute>
-            </xs:extension>
-        </xs:complexContent>
-    </xs:complexType>
-
-    <xs:complexType name="TSignalDictionaries">
-        <xs:sequence>
-            <xs:element name="SignalDictionary" maxOccurs="unbounded">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="any"/>
+							<xs:enumeration value="ModelExchange"/>
+							<xs:enumeration value="CoSimulation"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:attribute>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="TSignalDictionaries">
+		<xs:sequence>
+			<xs:element name="SignalDictionary" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">
                         This element defines a signal dictionary, describing the signal dictionary
                         entries present in the signal dictionary.
                         
@@ -262,10 +252,10 @@
                         there should be a layered specification that defines how embedding the content
                         works for that MIME type).
                     </xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:choice>
-                        <!-- NOTE: In XML Schema 1.1 this choice would also contain the following entry: 
+				</xs:annotation>
+				<xs:complexType>
+					<xs:choice>
+						<!-- NOTE: In XML Schema 1.1 this choice would also contain the following entry: 
                                         
                              <xs:element ref="ssb:SignalDictionary"/>
                                         
@@ -278,13 +268,13 @@
                              however if you have access to a 1.1 validator/validating parser, you can
                              use the 1.1 variant of these stylesheets instead.
                         -->
-                        <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-                    </xs:choice>
-                    <xs:attributeGroup ref="ssc:ABaseElement"/>
-                    <xs:attribute name="type" type="xs:string" use="optional" default="application/x-ssp-signal-dictionary"/>
-                    <xs:attribute name="source" type="xs:anyURI" use="optional">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
+						<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+					</xs:choice>
+					<xs:attributeGroup ref="ssc:ABaseElement"/>
+					<xs:attribute name="type" type="xs:string" use="optional" default="application/x-ssp-signal-dictionary"/>
+					<xs:attribute name="source" type="xs:anyURI" use="optional">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
                                 This attribute indicates the source of the signal dictionary as a URI
                                 (cf. RFC 3986).  For purposes of the resolution of relative URIs
                                 the base URI is the URI of the SSD.
@@ -296,11 +286,11 @@
                                 For the default type application/x-ssp-signal-dictionary such inline
                                 content must be an ssb:SignalDictionary element. 
                             </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="name" type="xs:string" use="required">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="name" type="xs:string" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
                                 This attribute gives the signal dictionary a name, which shall be
                                 unique within the directly enclosing system. The name is used for
                                 purposes of specifying the signal dictionary referenced by a
@@ -311,22 +301,18 @@
                                 until a match is found.  It is an error if no matching signal
                                 dictionary is found.
                             </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:complexType>
-            </xs:element>
-        </xs:sequence>
-    </xs:complexType>
-    
-    <xs:complexType name="TSignalDictionaryReference">
-        <xs:complexContent>
-            <xs:extension base="ssd:TElement">
-                <xs:sequence>
-                    <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
-                </xs:sequence>
-                <xs:attribute name="dictionary" type="xs:string" use="required">
-                    <xs:annotation>
-                        <xs:documentation xml:lang="en">
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TSignalDictionaryReference">
+		<xs:complexContent>
+			<xs:extension base="ssd:TElement">
+				<xs:attribute name="dictionary" type="xs:string" use="required">
+					<xs:annotation>
+						<xs:documentation xml:lang="en">
                             This attribute gives the name of the signal dictionary that is to
                             be referenced.  Name lookups occur in hierarchical fashion, i.e. 
                             the name is first looked up in the system that contains a signal
@@ -334,40 +320,39 @@
                             is performed on the enclosing system, etc., until a match is found.
                             It is an error if no matching signal dictionary is found.
                         </xs:documentation>
-                    </xs:annotation>
-                </xs:attribute>
-            </xs:extension>
-        </xs:complexContent>
-    </xs:complexType>
-    
-    <xs:complexType name="TSystem">
-        <xs:annotation>
-            <xs:documentation xml:lang="en">
+					</xs:annotation>
+				</xs:attribute>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="TSystem">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">
                 This element describes a system, which can contain components and other systems as elements,
                 connectors as an interface to the outside world, and connections connecting the connectors
                 of itself and of its elements to another.
             </xs:documentation>
-        </xs:annotation>
-        <xs:complexContent>
-            <xs:extension base="ssd:TElement">
-                <xs:sequence>
-                    <xs:element name="Elements" minOccurs="0">
-                        <xs:complexType>
-                            <xs:sequence>
-                                <xs:choice maxOccurs="unbounded">
-                                    <xs:element name="Component" type="ssd:TComponent"/>
-                                    <xs:element name="SignalDictionaryReference" type="ssd:TSignalDictionaryReference"/>
-                                    <xs:element name="System" type="ssd:TSystem"/>
-                                </xs:choice>
-                            </xs:sequence>
-                        </xs:complexType>
-                    </xs:element>
-                    <xs:element name="Connections" minOccurs="0">
-                        <xs:complexType>
-                            <xs:sequence>
-                                <xs:element name="Connection" maxOccurs="unbounded">
-                                    <xs:annotation>
-                                        <xs:documentation xml:lang="en">
+		</xs:annotation>
+		<xs:complexContent>
+			<xs:extension base="ssd:TElement">
+				<xs:sequence>
+					<xs:element name="Elements" minOccurs="0">
+						<xs:complexType>
+							<xs:sequence>
+								<xs:choice maxOccurs="unbounded">
+									<xs:element name="Component" type="ssd:TComponent"/>
+									<xs:element name="SignalDictionaryReference" type="ssd:TSignalDictionaryReference"/>
+									<xs:element name="System" type="ssd:TSystem"/>
+								</xs:choice>
+							</xs:sequence>
+						</xs:complexType>
+					</xs:element>
+					<xs:element name="Connections" minOccurs="0">
+						<xs:complexType>
+							<xs:sequence>
+								<xs:element name="Connection" maxOccurs="unbounded">
+									<xs:annotation>
+										<xs:documentation xml:lang="en">
                                             This element specifies a connection between two connectors,
                                             either of the system or its directly contained elements.
                                             Note that connections between connectors on a system are
@@ -393,20 +378,20 @@
                                             must match, i.e. either both are input or both output or both
                                             parameter or both calculatedParameter.
                                         </xs:documentation>
-                                    </xs:annotation>
-                                    <xs:complexType>
-                                        <xs:sequence>
-                                            <xs:group ref="ssc:GTransformationChoice" minOccurs="0" maxOccurs="1">
-                                                <xs:annotation>
-                                                    <xs:documentation xml:lang="en">
+									</xs:annotation>
+									<xs:complexType>
+										<xs:sequence>
+											<xs:group ref="ssc:GTransformationChoice" minOccurs="0" maxOccurs="1">
+												<xs:annotation>
+													<xs:documentation xml:lang="en">
                                                         This optional element specifies a transformation that is to be applied to the
                                                         source value prior to its conveyance to the target.
                                                     </xs:documentation>
-                                                </xs:annotation>
-                                            </xs:group>
-                                            <xs:element name="ConnectionGeometry" minOccurs="0">
-                                                <xs:annotation>
-                                                    <xs:documentation xml:lang="en">
+												</xs:annotation>
+											</xs:group>
+											<xs:element name="ConnectionGeometry" minOccurs="0">
+												<xs:annotation>
+													<xs:documentation xml:lang="en">
                                                         This optional element defines the geometry information of the connection.
                                                         The start and end coordinates of the connection are derived automatically
                                                         through the coordinates of the corresponding connectors.  The only relevant
@@ -419,68 +404,68 @@
                                                         Note that x and y coordinates are in the coordinate system of the
                                                         enclosing system.
                                                     </xs:documentation>
-                                                </xs:annotation>
-                                                <xs:complexType>
-                                                    <xs:attribute name="pointsX" use="required">
-                                                        <xs:simpleType>
-                                                            <xs:list itemType="xs:double"/>
-                                                        </xs:simpleType>
-                                                    </xs:attribute>
-                                                    <xs:attribute name="pointsY" use="required">
-                                                        <xs:simpleType>
-                                                            <xs:list itemType="xs:double"/>
-                                                        </xs:simpleType>
-                                                    </xs:attribute>
-                                                </xs:complexType>
-                                            </xs:element>
-                                            <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
-                                        </xs:sequence>
-                                        <xs:attributeGroup ref="ssc:ABaseElement"/>
-                                        <xs:attribute name="startElement" type="xs:string" use="optional">
-                                            <xs:annotation>
-                                                <xs:documentation xml:lang="en">
+												</xs:annotation>
+												<xs:complexType>
+													<xs:attribute name="pointsX" use="required">
+														<xs:simpleType>
+															<xs:list itemType="xs:double"/>
+														</xs:simpleType>
+													</xs:attribute>
+													<xs:attribute name="pointsY" use="required">
+														<xs:simpleType>
+															<xs:list itemType="xs:double"/>
+														</xs:simpleType>
+													</xs:attribute>
+												</xs:complexType>
+											</xs:element>
+											<xs:group ref="ssc:GElementCommon"/>
+										</xs:sequence>
+										<xs:attributeGroup ref="ssc:ABaseElement"/>
+										<xs:attribute name="startElement" type="xs:string" use="optional">
+											<xs:annotation>
+												<xs:documentation xml:lang="en">
                                                     This attribute gives the name of the element that contains
                                                     the connector given as startConnector.  If the attribute
                                                     is elided, then the startConnector names a connector on
                                                     this system.
                                                 </xs:documentation>
-                                            </xs:annotation>
-                                        </xs:attribute>
-                                        <xs:attribute name="startConnector" type="xs:string" use="required">
-                                            <xs:annotation>
-                                                <xs:documentation xml:lang="en">
+											</xs:annotation>
+										</xs:attribute>
+										<xs:attribute name="startConnector" type="xs:string" use="required">
+											<xs:annotation>
+												<xs:documentation xml:lang="en">
                                                     This attribute gives the name of the connector that is
                                                     the start of the connection.  If startElement is not
                                                     supplied this indicates a connector on this system,
                                                     otherwise the connector is to be found on the given
                                                     element.
                                                 </xs:documentation>
-                                            </xs:annotation>
-                                        </xs:attribute>
-                                        <xs:attribute name="endElement" type="xs:string" use="optional">
-                                            <xs:annotation>
-                                                <xs:documentation xml:lang="en">
+											</xs:annotation>
+										</xs:attribute>
+										<xs:attribute name="endElement" type="xs:string" use="optional">
+											<xs:annotation>
+												<xs:documentation xml:lang="en">
                                                     This attribute gives the name of the element that contains
                                                     the connector given as endConnector.  If the attribute
                                                     is elided, then the endConnector names a connector on
                                                     this system.
                                                 </xs:documentation>
-                                            </xs:annotation>
-                                        </xs:attribute>
-                                        <xs:attribute name="endConnector" type="xs:string" use="required">
-                                            <xs:annotation>
-                                                <xs:documentation xml:lang="en">
+											</xs:annotation>
+										</xs:attribute>
+										<xs:attribute name="endConnector" type="xs:string" use="required">
+											<xs:annotation>
+												<xs:documentation xml:lang="en">
                                                     This attribute gives the name of the connector that is
                                                     the end of the connection.  If endElement is not
                                                     supplied this indicates a connector on this system,
                                                     otherwise the connector is to be found on the given
                                                     element.
                                                 </xs:documentation>
-                                            </xs:annotation>
-                                        </xs:attribute>
-                                        <xs:attribute name="suppressUnitConversion" type="xs:boolean" use="optional" default="false">
-                                            <xs:annotation>
-                                                <xs:documentation xml:lang="en">
+											</xs:annotation>
+										</xs:attribute>
+										<xs:attribute name="suppressUnitConversion" type="xs:boolean" use="optional" default="false">
+											<xs:annotation>
+												<xs:documentation xml:lang="en">
                                                     This attribute specifies whether automatic conversions between start
                                                     and end connector are performed using unit information potentially
                                                     available for both start and end definitions.  If this attribute is
@@ -492,17 +477,17 @@
                                                     is performed instead of any unit conversions, whereas otherwise the
                                                     linear transformation is performed in addition to any unit conversions.
                                                 </xs:documentation>
-                                            </xs:annotation>
-                                        </xs:attribute>
-                                    </xs:complexType>
-                                </xs:element>
-                            </xs:sequence>
-                        </xs:complexType>
-                    </xs:element>
-                    <xs:element name="SignalDictionaries" minOccurs="0" type="ssd:TSignalDictionaries"/>
-                    <xs:element name="SystemGeometry" minOccurs="0">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
+											</xs:annotation>
+										</xs:attribute>
+									</xs:complexType>
+								</xs:element>
+							</xs:sequence>
+						</xs:complexType>
+					</xs:element>
+					<xs:element name="SignalDictionaries" type="ssd:TSignalDictionaries" minOccurs="0"/>
+					<xs:element name="SystemGeometry" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
                                 This optional element defines the extent of the system canvas. 
                                 (x1,y1) and (x2,y2) define the lower-left and upper-right 
                                 corner, respectively.
@@ -522,17 +507,17 @@
                                 is the respective coordinate of the sub-system when instantiated
                                 in the parent system after rotation.
                             </xs:documentation>
-                        </xs:annotation>
-                        <xs:complexType>
-                            <xs:attribute name="x1" type="xs:double" use="required"/>
-                            <xs:attribute name="y1" type="xs:double" use="required"/>
-                            <xs:attribute name="x2" type="xs:double" use="required"/>
-                            <xs:attribute name="y2" type="xs:double" use="required"/>
-                        </xs:complexType>
-                    </xs:element>
-                    <xs:element name="GraphicalElements" minOccurs="0">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
+						</xs:annotation>
+						<xs:complexType>
+							<xs:attribute name="x1" type="xs:double" use="required"/>
+							<xs:attribute name="y1" type="xs:double" use="required"/>
+							<xs:attribute name="x2" type="xs:double" use="required"/>
+							<xs:attribute name="y2" type="xs:double" use="required"/>
+						</xs:complexType>
+					</xs:element>
+					<xs:element name="GraphicalElements" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
                                 This optional element contains the set of purely graphical elements
                                 that are contained in the system, e.g. things like notes, which have no
                                 semantic impact on the system but aid in presentation of the system in
@@ -543,13 +528,13 @@
                                 in the future more elements might be added as needed for exchange of
                                 graphical information.
                             </xs:documentation>
-                        </xs:annotation>
-                        <xs:complexType>
-                            <xs:sequence>
-                                <xs:choice maxOccurs="unbounded">
-                                    <xs:element name="Note">
-                                        <xs:annotation>
-                                            <xs:documentation xml:lang="en">
+						</xs:annotation>
+						<xs:complexType>
+							<xs:sequence>
+								<xs:choice maxOccurs="unbounded">
+									<xs:element name="Note">
+										<xs:annotation>
+											<xs:documentation xml:lang="en">
                                                 This element defines a graphical note to be placed on the canvas of the
                                                 enclosing system.  It is sized using the attributes so that the coordinates
                                                 (x1,y1) and (x2,y2) define the positions of the lower-left and upper-right
@@ -562,33 +547,31 @@
                                                 or other means) to show the remainder of the note text.  Inside the text
                                                 attribute, newlines indicate paragraph breaks.
                                             </xs:documentation>
-                                        </xs:annotation>
-                                        <xs:complexType>
-                                            <xs:attribute name="x1" type="xs:double" use="required"/>
-                                            <xs:attribute name="y1" type="xs:double" use="required"/>
-                                            <xs:attribute name="x2" type="xs:double" use="required"/>
-                                            <xs:attribute name="y2" type="xs:double" use="required"/>
-                                            <xs:attribute name="text" type="xs:string" use="required"/>
-                                        </xs:complexType>
-                                    </xs:element>
-                                </xs:choice>
-                            </xs:sequence>
-                        </xs:complexType>
-                    </xs:element>
-                    <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
-                </xs:sequence>
-            </xs:extension>
-        </xs:complexContent>
-    </xs:complexType>
-
-    <xs:complexType name="TConnectors">
-        <xs:sequence>
-            <xs:element name="Connector" maxOccurs="unbounded">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:group ref="ssc:GTypeChoice" minOccurs="0">
-                            <xs:annotation>
-                                <xs:documentation xml:lang="en">
+										</xs:annotation>
+										<xs:complexType>
+											<xs:attribute name="x1" type="xs:double" use="required"/>
+											<xs:attribute name="y1" type="xs:double" use="required"/>
+											<xs:attribute name="x2" type="xs:double" use="required"/>
+											<xs:attribute name="y2" type="xs:double" use="required"/>
+											<xs:attribute name="text" type="xs:string" use="required"/>
+										</xs:complexType>
+									</xs:element>
+								</xs:choice>
+							</xs:sequence>
+						</xs:complexType>
+					</xs:element>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="TConnectors">
+		<xs:sequence>
+			<xs:element name="Connector" maxOccurs="unbounded">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:group ref="ssc:GTypeChoice" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">
                                     This element gives the type of the connector.
                                     
                                     If a type is not supplied, the type is determined through
@@ -600,11 +583,11 @@
                                     differs from the type of the underlying FMU variable this
                                     constitutes an error.
                                 </xs:documentation>
-                            </xs:annotation>
-                        </xs:group>
-                        <xs:element name="ConnectorGeometry" minOccurs="0">
-                            <xs:annotation>
-                                <xs:documentation xml:lang="en">
+							</xs:annotation>
+						</xs:group>
+						<xs:element name="ConnectorGeometry" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">
                                     This optional element gives the geometry information of the connector.
                                     Note that x and y coordinates are in a special coordinate system, where
                                     0,0 is the lower-left corner of the component/system, and 1,1 is the
@@ -616,18 +599,18 @@
                                     determined by the ElementGeometry for the outside view, and the
                                     one determined by SystemGeometry for the inside view.
                                 </xs:documentation>
-                            </xs:annotation>
-                            <xs:complexType>
-                                <xs:attribute name="x" type="xs:double" use="required"/>
-                                <xs:attribute name="y" type="xs:double" use="required"/>
-                            </xs:complexType>
-                        </xs:element>
-                        <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
-                    </xs:sequence>
-                    <xs:attributeGroup ref="ssc:ABaseElement"/>
-                    <xs:attribute name="name" type="xs:string" use="required">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
+							</xs:annotation>
+							<xs:complexType>
+								<xs:attribute name="x" type="xs:double" use="required"/>
+								<xs:attribute name="y" type="xs:double" use="required"/>
+							</xs:complexType>
+						</xs:element>
+						<xs:group ref="ssc:GElementCommon"/>
+					</xs:sequence>
+					<xs:attributeGroup ref="ssc:ABaseElement"/>
+					<xs:attribute name="name" type="xs:string" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
                                 This attribute gives the connector a name, which
                                 shall be unique within the component or system and,
                                 for components, must match the name of a relevant 
@@ -640,11 +623,11 @@
                                 be present which are referenced in connections inside
                                 the SSD.
                             </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="kind" use="required">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="kind" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
                                 This attribute specifies the kind of the given connector,
                                 which indicates whether the connector is an input, an output,
                                 both (inout), a constant, a parameter, a calculated parameter
@@ -677,29 +660,28 @@
                                 This can be used for example to allow a connector to function as
                                 both an input and output within the same SignalDictionaryReference.
                             </xs:documentation>
-                        </xs:annotation>
-                        <xs:simpleType>
-                            <xs:restriction base="xs:string">
-                                <xs:enumeration value="input"/>
-                                <xs:enumeration value="output"/>
-                                <xs:enumeration value="parameter"/>
-                                <xs:enumeration value="calculatedParameter"/>
-                                <xs:enumeration value="structuralParameter"/>
-                                <xs:enumeration value="constant"/>
-                                <xs:enumeration value="inout"/>
-                            </xs:restriction>
-                        </xs:simpleType>
-                    </xs:attribute>
-                </xs:complexType>
-            </xs:element>
-        </xs:sequence>
-    </xs:complexType>
-
-    <xs:complexType name="TParameterBindings">
-        <xs:sequence maxOccurs="unbounded">
-            <xs:element name="ParameterBinding">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="xs:string">
+								<xs:enumeration value="input"/>
+								<xs:enumeration value="output"/>
+								<xs:enumeration value="parameter"/>
+								<xs:enumeration value="calculatedParameter"/>
+								<xs:enumeration value="structuralParameter"/>
+								<xs:enumeration value="constant"/>
+								<xs:enumeration value="inout"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TParameterBindings">
+		<xs:sequence maxOccurs="unbounded">
+			<xs:element name="ParameterBinding">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">
                         This provides a parameter binding for a component or system.  For FMU components this
                         allows the parametrization of the FMU's parameters and start values of other variables
                         with a parameter source (e.g. a parameter file).  Note that in this case the names
@@ -750,12 +732,12 @@
                         of the system.  Therefore they take priority over any of the existing parameter bindings
                         (for parameters with identical names).
                     </xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element name="ParameterValues" minOccurs="0">
-                            <xs:annotation>
-                                <xs:documentation xml:lang="en">
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="ParameterValues" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">
                                     This optional element can be used to provide parameter values inline
                                     to the parameter binding, in which case the source attribute of the
                                     ParameterBinding element must be empty.
@@ -766,10 +748,10 @@
                                     MIME type (in that case there should be a layered specification that
                                     defines how embedding the content works for that MIME type).
                                 </xs:documentation>
-                            </xs:annotation>
-                            <xs:complexType>
-                                <xs:choice>
-                                    <!-- NOTE: In XML Schema 1.1 this choice would also contain the following entry: 
+							</xs:annotation>
+							<xs:complexType>
+								<xs:choice>
+									<!-- NOTE: In XML Schema 1.1 this choice would also contain the following entry: 
                                         
                                          <xs:element ref="ssv:ParameterSet"/>
                                         
@@ -782,13 +764,13 @@
                                          however if you have access to a 1.1 validator/validating parser, you can
                                          use the 1.1 variant of these stylesheets instead.
                                     -->
-                                    <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-                                </xs:choice>
-                            </xs:complexType>
-                        </xs:element>
-                        <xs:element name="ParameterMapping" minOccurs="0">
-                            <xs:annotation>
-                                <xs:documentation xml:lang="en">
+									<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+								</xs:choice>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="ParameterMapping" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">
                                     This element provides an optional parameter mapping, which specifies how
                                     the parameter names and values provided in the parameter source are to be
                                     mapped to the parameters of the component or system in question.  If no
@@ -807,10 +789,10 @@
                                     there should be a layered specification that defines how embedding the content
                                     works for that MIME type).
                                 </xs:documentation>
-                            </xs:annotation>
-                            <xs:complexType>
-                                <xs:choice>
-                                    <!-- NOTE: In XML Schema 1.1 this choice would also contain the following entry: 
+							</xs:annotation>
+							<xs:complexType>
+								<xs:choice>
+									<!-- NOTE: In XML Schema 1.1 this choice would also contain the following entry: 
                                         
                                          <xs:element ref="ssm:ParameterMapping"/>
                                         
@@ -823,13 +805,13 @@
                                          however if you have access to a 1.1 validator/validating parser, you can
                                          use the 1.1 variant of these stylesheets instead.
                                     -->
-                                    <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-                                </xs:choice>
-                                <xs:attributeGroup ref="ssc:ABaseElement"/>
-                                <xs:attribute name="type" type="xs:string" use="optional" default="application/x-ssp-parameter-mapping"/>
-                                <xs:attribute name="source" type="xs:anyURI" use="optional">
-                                    <xs:annotation>
-                                        <xs:documentation xml:lang="en">
+									<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+								</xs:choice>
+								<xs:attributeGroup ref="ssc:ABaseElement"/>
+								<xs:attribute name="type" type="xs:string" use="optional" default="application/x-ssp-parameter-mapping"/>
+								<xs:attribute name="source" type="xs:anyURI" use="optional">
+									<xs:annotation>
+										<xs:documentation xml:lang="en">
                                             This attribute indicates the source of the parameter mapping as a URI
                                             (cf. RFC 3986).  For purposes of the resolution of relative URIs
                                             the base URI is the URI of the SSD, if the sourcebase attribute
@@ -842,42 +824,42 @@
                                             inline as contents of the ParameterMapping element, which must be
                                             empty otherwise.
                                         </xs:documentation>
-                                    </xs:annotation>
-                                </xs:attribute>
-                                <xs:attribute name="sourceBase" use="optional" default="SSD">
-                                    <xs:annotation>
-                                        <xs:documentation xml:lang="en">
+									</xs:annotation>
+								</xs:attribute>
+								<xs:attribute name="sourceBase" use="optional" default="SSD">
+									<xs:annotation>
+										<xs:documentation xml:lang="en">
                                             Defines the base the source URI is resolved against:  If the attribute
                                             is missing or is specified as SSD, the source is resolved against the
                                             URI of the SSD, if the attribute is specified as component the URI is
                                             resolved against the (resolved) URI of the component source.
                                         </xs:documentation>
-                                    </xs:annotation>
-                                    <xs:simpleType>
-                                        <xs:restriction base="xs:string">
-                                            <xs:enumeration value="SSD"/>
-                                            <xs:enumeration value="component"/>
-                                        </xs:restriction>
-                                    </xs:simpleType>
-                                </xs:attribute>
-                            </xs:complexType>
-                        </xs:element>
-                        <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
-                    </xs:sequence>
-                    <xs:attributeGroup ref="ssc:ABaseElement"/>
-                    <xs:attribute name="type" type="xs:string" use="optional" default="application/x-ssp-parameter-set">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
+									</xs:annotation>
+									<xs:simpleType>
+										<xs:restriction base="xs:string">
+											<xs:enumeration value="SSD"/>
+											<xs:enumeration value="component"/>
+										</xs:restriction>
+									</xs:simpleType>
+								</xs:attribute>
+							</xs:complexType>
+						</xs:element>
+						<xs:group ref="ssc:GElementCommon"/>
+					</xs:sequence>
+					<xs:attributeGroup ref="ssc:ABaseElement"/>
+					<xs:attribute name="type" type="xs:string" use="optional" default="application/x-ssp-parameter-set">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
                                 This attribute specifies the MIME type of the parameter source, which defaults
                                 to application/x-ssp-parameter-set to indicate the SSP parameter set file format.
                                 No further types are currently defined, but can of course be added at a later
                                 date, e.g. for pre-existing parameter file formats, like CDF, etc.
                             </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="source" type="xs:anyURI" use="optional">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="source" type="xs:anyURI" use="optional">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
                                 This attribute indicates the source of the parameters as a URI
                                 (cf. RFC 3986).  For purposes of the resolution of relative URIs
                                 the base URI is the URI of the SSD, if the sourcebase attribute
@@ -893,27 +875,27 @@
                                 inline as contents of a ParameterValues element, which must not be
                                 present otherwise.
                             </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="sourceBase" use="optional" default="SSD">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="sourceBase" use="optional" default="SSD">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
                                 Defines the base the source URI is resolved against:  If the attribute
                                 is missing or is specified as SSD, the source is resolved against the
                                 URI of the SSD, if the attribute is specified as component the URI is
                                 resolved against the (resolved) URI of the component source.
                             </xs:documentation>
-                        </xs:annotation>
-                        <xs:simpleType>
-                            <xs:restriction base="xs:string">
-                                <xs:enumeration value="SSD"/>
-                                <xs:enumeration value="component"/>
-                            </xs:restriction>
-                        </xs:simpleType>
-                    </xs:attribute>
-                    <xs:attribute name="prefix" type="xs:string" use="optional" default="">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="xs:string">
+								<xs:enumeration value="SSD"/>
+								<xs:enumeration value="component"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="prefix" type="xs:string" use="optional" default="">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
                                 Defines the optional prefix for name resolution and mapping purposes
                                 for this binding.  If this attribute is empty or not supplied no
                                 prefix is used for name resolution and mapping, otherwise the specified
@@ -925,33 +907,32 @@
                                 as a prefix on the binding, thus causing all parameter names in the parameter
                                 set to be treated as if they were specified with proper hierarchical names.
                             </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:complexType>
-            </xs:element>
-        </xs:sequence>
-    </xs:complexType>
-    
-    <xs:complexType name="TDefaultExperiment">
-        <xs:annotation>
-            <xs:documentation xml:lang="en">
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TDefaultExperiment">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">
                 The attributes of this element, if present, specify reasonable default values
                 for running an experiment of the given system.  Any tool is free to ignore this
                 information.
             </xs:documentation>
-        </xs:annotation>
-        <xs:sequence>
-            <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
-        </xs:sequence>
-        <xs:attribute name="startTime" type="xs:double" use="optional">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">Default start time of simulation</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="stopTime" type="xs:double" use="optional">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">Default stop time of simulation</xs:documentation>
-            </xs:annotation>            
-        </xs:attribute>
-    </xs:complexType>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:group ref="ssc:GElementCommon"/>
+		</xs:sequence>
+		<xs:attribute name="startTime" type="xs:double" use="optional">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">Default start time of simulation</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="stopTime" type="xs:double" use="optional">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">Default stop time of simulation</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
 </xs:schema>

--- a/schema/SystemStructureDescription11.xsd
+++ b/schema/SystemStructureDescription11.xsd
@@ -1,14 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
-    xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
-    xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
-    xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
-    xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
-    xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
-    targetNamespace="http://ssp-standard.org/SSP1/SystemStructureDescription"
-    xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1">
-    <xs:annotation>
-        <xs:documentation xml:lang="en">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" targetNamespace="http://ssp-standard.org/SSP1/SystemStructureDescription" elementFormDefault="qualified" vc:minVersion="1.1">
+	<xs:annotation>
+		<xs:documentation xml:lang="en">
             This is the XML Schema 1.1 schema for the MAP SSP
             SystemStructureDescription 2.0 format.  It is provided
             as a non-normative alternative to the XML Schema 1.0 schema
@@ -46,58 +39,55 @@
             OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
             POSSIBILITY OF SUCH DAMAGE.
         </xs:documentation>
-    </xs:annotation>
-    
-    <xs:import namespace="http://ssp-standard.org/SSP1/SystemStructureCommon" schemaLocation="SystemStructureCommon.xsd"/>
-    <xs:import namespace="http://ssp-standard.org/SSP1/SystemStructureParameterValues" schemaLocation="SystemStructureParameterValues.xsd"/>
-    <xs:import namespace="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" schemaLocation="SystemStructureParameterMapping.xsd"/>
-    <xs:import namespace="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" schemaLocation="SystemStructureSignalDictionary.xsd"/>
-    
-    <xs:element name="SystemStructureDescription">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="System" type="ssd:TSystem"/>
-                <xs:element name="Enumerations" minOccurs="0" type="ssc:TEnumerations"/>
-                <xs:element name="Units" minOccurs="0" type="ssc:TUnits"/>
-                <xs:element name="DefaultExperiment" minOccurs="0" type="ssd:TDefaultExperiment"/>
-                <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
-            </xs:sequence>
-            <xs:attribute name="version" use="required">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
+	</xs:annotation>
+	<xs:import namespace="http://ssp-standard.org/SSP1/SystemStructureCommon" schemaLocation="SystemStructureCommon.xsd"/>
+	<xs:import namespace="http://ssp-standard.org/SSP1/SystemStructureParameterValues" schemaLocation="SystemStructureParameterValues.xsd"/>
+	<xs:import namespace="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" schemaLocation="SystemStructureParameterMapping.xsd"/>
+	<xs:import namespace="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" schemaLocation="SystemStructureSignalDictionary.xsd"/>
+	<xs:element name="SystemStructureDescription">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="System" type="ssd:TSystem"/>
+				<xs:element name="Enumerations" type="ssc:TEnumerations" minOccurs="0"/>
+				<xs:element name="Units" type="ssc:TUnits" minOccurs="0"/>
+				<xs:element name="DefaultExperiment" type="ssd:TDefaultExperiment" minOccurs="0"/>
+				<xs:group ref="ssc:GElementCommon"/>
+			</xs:sequence>
+			<xs:attribute name="version" use="required">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">
                         Version of SSD format, 2.0-alpha for this release.
                     </xs:documentation>
-                </xs:annotation>
-                <xs:simpleType>
-                    <xs:restriction base="xs:normalizedString">
-                        <xs:pattern value="2[.][0-9]+(-.+)"/>
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:attribute>
-            <xs:attribute name="name" type="xs:string" use="required">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:normalizedString">
+						<xs:pattern value="2[.][0-9]+(-.+)"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="name" type="xs:string" use="required">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">
                         This attribute gives the system structure a name, which can be used
                         for purposes of presenting the system structure to the user, e.g.
                         when selecting individual variant SSDs from an SSP.
                     </xs:documentation>
-                </xs:annotation>
-            </xs:attribute>
-            <xs:attributeGroup ref="ssc:ABaseElement"/>
-            <xs:attributeGroup ref="ssc:ATopLevelMetaData"/>
-        </xs:complexType>
-    </xs:element>
-        
-    <xs:complexType name="TElement">
-        <xs:annotation>
-            <xs:documentation xml:lang="en">
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attributeGroup ref="ssc:ABaseElement"/>
+			<xs:attributeGroup ref="ssc:ATopLevelMetaData"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="TElement">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">
                 This is the base type for all elements, currently consisting of components and systems.
             </xs:documentation>
-        </xs:annotation>
-        <xs:sequence>
-            <xs:element name="Connectors" minOccurs="0" type="ssd:TConnectors">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Connectors" type="ssd:TConnectors" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">
                         The set of connectors of this element, which represent
                         the interface of the element to the outside world.
  
@@ -111,11 +101,11 @@
                         be present which are referenced in connections inside
                         the SSD.
                     </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element name="ElementGeometry" minOccurs="0">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="ElementGeometry" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">
                         This optional element defines the geometry information of the component.
                         (x1,y1) and (x2,y2) define the positions of the lower-left and upper-right
                         corners of the component in the coordinate system of the parent.
@@ -133,64 +123,61 @@
                         ratio. The optional attribute iconFlip defines whether any flipping indicated
                         by (x1,y1), (x2, y2) shall be applied to the icon graphics, too.
                     </xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:attribute name="x1" type="xs:double" use="required"/>
-                    <xs:attribute name="y1" type="xs:double" use="required"/>
-                    <xs:attribute name="x2" type="xs:double" use="required"/>
-                    <xs:attribute name="y2" type="xs:double" use="required"/>
-                    <xs:attribute name="rotation" type="xs:double" use="optional" default="0.0"/>
-                    <xs:attribute name="iconSource" type="xs:anyURI" use="optional"/>
-                    <xs:attribute name="iconRotation" type="xs:double" use="optional" default="0.0"/>
-                    <xs:attribute name="iconFlip" type="xs:boolean" use="optional" default="false"/>
-                    <xs:attribute name="iconFixedAspectRatio" type="xs:boolean" use="optional" default="false"/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="ParameterBindings" minOccurs="0" type="ssd:TParameterBindings">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
+				</xs:annotation>
+				<xs:complexType>
+					<xs:attribute name="x1" type="xs:double" use="required"/>
+					<xs:attribute name="y1" type="xs:double" use="required"/>
+					<xs:attribute name="x2" type="xs:double" use="required"/>
+					<xs:attribute name="y2" type="xs:double" use="required"/>
+					<xs:attribute name="rotation" type="xs:double" use="optional" default="0.0"/>
+					<xs:attribute name="iconSource" type="xs:anyURI" use="optional"/>
+					<xs:attribute name="iconRotation" type="xs:double" use="optional" default="0.0"/>
+					<xs:attribute name="iconFlip" type="xs:boolean" use="optional" default="false"/>
+					<xs:attribute name="iconFixedAspectRatio" type="xs:boolean" use="optional" default="false"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="ParameterBindings" type="ssd:TParameterBindings" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">
                         The set of parameter bindings for this element.
                     </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-        </xs:sequence>
-        <xs:attributeGroup ref="ssc:ABaseElement"/>
-        <xs:attribute name="name" use="required">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
+				</xs:annotation>
+			</xs:element>
+			<xs:group ref="ssc:GElementCommon"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ssc:ABaseElement"/>
+		<xs:attribute name="name" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
                     This attribute gives the element a name, which shall be unique
                     within the directly enclosing system. The name is used for
                     purposes of specifying the element's connectors in connections.
                 </xs:documentation>
-            </xs:annotation>
-            <xs:simpleType>
-                <xs:restriction base="xs:string">
-                    <xs:minLength value="1"/>
-                </xs:restriction>
-            </xs:simpleType>
-        </xs:attribute>
-    </xs:complexType>
-    
-    <xs:complexType name="TComponent">
-        <xs:complexContent>
-            <xs:extension base="ssd:TElement">
-                <xs:sequence>
-                    <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
-                </xs:sequence>
-                <xs:attribute name="type" type="xs:string" use="optional" default="application/x-fmu-sharedlibrary">
-                    <xs:annotation>
-                        <xs:documentation xml:lang="en">
+			</xs:annotation>
+			<xs:simpleType>
+				<xs:restriction base="xs:string">
+					<xs:minLength value="1"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="TComponent">
+		<xs:complexContent>
+			<xs:extension base="ssd:TElement">
+				<xs:attribute name="type" type="xs:string" use="optional" default="application/x-fmu-sharedlibrary">
+					<xs:annotation>
+						<xs:documentation xml:lang="en">
                             This attribute specifies the MIME type of the component, which defaults to
                             application/x-fmu-sharedlibrary to indicate an FMU.  When referencing another
                             system structure definition file, the MIME type application/x-ssp-definition
                             is used, and the MIME type application/x-ssp-package is used for referenced
                             system structure packages (SSPs). No further types are currently defined.
                         </xs:documentation>
-                    </xs:annotation>
-                </xs:attribute>
-                <xs:attribute name="source" type="xs:anyURI" use="required">
-                    <xs:annotation>
-                        <xs:documentation xml:lang="en">
+					</xs:annotation>
+				</xs:attribute>
+				<xs:attribute name="source" type="xs:anyURI" use="required">
+					<xs:annotation>
+						<xs:documentation xml:lang="en">
                             This attribute indicates the source of the component as an URI
                             (cf. RFC 3986).  For purposes of the resolution of relative URIs
                             the base URI is the URI of the SSD.  Therefore for components
@@ -226,11 +213,11 @@
                             support any absolute URIs and any specific URI schemes (but are of
                             course allowed to support any and all kinds of URIs where useful).
                         </xs:documentation>
-                    </xs:annotation>
-                </xs:attribute>
-                <xs:attribute name="implementation" use="optional" default="any">
-                    <xs:annotation>
-                        <xs:documentation xml:lang="en">
+					</xs:annotation>
+				</xs:attribute>
+				<xs:attribute name="implementation" use="optional" default="any">
+					<xs:annotation>
+						<xs:documentation xml:lang="en">
                             When the referenced component is an FMU that contains multiple
                             implementations (e.g. Co-Simulation and Model Exchange), this optional
                             attribute can be used to determine which FMU implementation should be
@@ -240,24 +227,23 @@
                             FMU implementation must be used.  It is an error if the specified type
                             of FMU implementation is not present in the FMU.
                         </xs:documentation>
-                    </xs:annotation>
-                    <xs:simpleType>
-                        <xs:restriction base="xs:string">
-                            <xs:enumeration value="any"/>
-                            <xs:enumeration value="ModelExchange"/>
-                            <xs:enumeration value="CoSimulation"/>
-                        </xs:restriction>
-                    </xs:simpleType>
-                </xs:attribute>
-            </xs:extension>
-        </xs:complexContent>
-    </xs:complexType>
-
-    <xs:complexType name="TSignalDictionaries">
-        <xs:sequence>
-            <xs:element name="SignalDictionary" maxOccurs="unbounded">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="any"/>
+							<xs:enumeration value="ModelExchange"/>
+							<xs:enumeration value="CoSimulation"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:attribute>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="TSignalDictionaries">
+		<xs:sequence>
+			<xs:element name="SignalDictionary" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">
                         This element defines a signal dictionary, describing the signal dictionary
                         entries present in the signal dictionary.
                         
@@ -271,17 +257,17 @@
                         there should be a layered specification that defines how embedding the content
                         works for that MIME type).
                     </xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:choice>
-                        <xs:element ref="ssb:SignalDictionary"/>
-                        <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-                    </xs:choice>
-                    <xs:attributeGroup ref="ssc:ABaseElement"/>
-                    <xs:attribute name="type" type="xs:string" use="optional" default="application/x-ssp-signal-dictionary"/>
-                    <xs:attribute name="source" type="xs:anyURI" use="optional">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
+				</xs:annotation>
+				<xs:complexType>
+					<xs:choice>
+						<xs:element ref="ssb:SignalDictionary"/>
+						<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+					</xs:choice>
+					<xs:attributeGroup ref="ssc:ABaseElement"/>
+					<xs:attribute name="type" type="xs:string" use="optional" default="application/x-ssp-signal-dictionary"/>
+					<xs:attribute name="source" type="xs:anyURI" use="optional">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
                                 This attribute indicates the source of the signal dictionary as a URI
                                 (cf. RFC 3986).  For purposes of the resolution of relative URIs
                                 the base URI is the URI of the SSD.
@@ -293,11 +279,11 @@
                                 For the default type application/x-ssp-signal-dictionary such inline
                                 content must be an ssb:SignalDictionary element.
                             </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="name" type="xs:string" use="required">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="name" type="xs:string" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
                                 This attribute gives the signal dictionary a name, which shall be
                                 unique within the directly enclosing system. The name is used for
                                 purposes of specifying the signal dictionary referenced by a
@@ -308,22 +294,18 @@
                                 until a match is found.  It is an error if no matching signal
                                 dictionary is found.
                             </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:complexType>
-            </xs:element>
-        </xs:sequence>
-    </xs:complexType>
-    
-    <xs:complexType name="TSignalDictionaryReference">
-        <xs:complexContent>
-            <xs:extension base="ssd:TElement">
-                <xs:sequence>
-                    <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
-                </xs:sequence>
-                <xs:attribute name="dictionary" type="xs:string" use="required">
-                    <xs:annotation>
-                        <xs:documentation xml:lang="en">
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TSignalDictionaryReference">
+		<xs:complexContent>
+			<xs:extension base="ssd:TElement">
+				<xs:attribute name="dictionary" type="xs:string" use="required">
+					<xs:annotation>
+						<xs:documentation xml:lang="en">
                             This attribute gives the name of the signal dictionary that is to
                             be referenced.  Name lookups occur in hierarchical fashion, i.e. 
                             the name is first looked up in the system that contains a signal
@@ -331,40 +313,39 @@
                             is performed on the enclosing system, etc., until a match is found.
                             It is an error if no matching signal dictionary is found.
                         </xs:documentation>
-                    </xs:annotation>
-                </xs:attribute>
-            </xs:extension>
-        </xs:complexContent>
-    </xs:complexType>
-    
-    <xs:complexType name="TSystem">
-        <xs:annotation>
-            <xs:documentation xml:lang="en">
+					</xs:annotation>
+				</xs:attribute>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="TSystem">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">
                 This element describes a system, which can contain components and other systems as elements,
                 connectors as an interface to the outside world, and connections connecting the connectors
                 of itself and of its elements to another.
             </xs:documentation>
-        </xs:annotation>
-        <xs:complexContent>
-            <xs:extension base="ssd:TElement">
-                <xs:sequence>
-                    <xs:element name="Elements" minOccurs="0">
-                        <xs:complexType>
-                            <xs:sequence>
-                                <xs:choice maxOccurs="unbounded">
-                                    <xs:element name="Component" type="ssd:TComponent"/>
-                                    <xs:element name="SignalDictionaryReference" type="ssd:TSignalDictionaryReference"/>
-                                    <xs:element name="System" type="ssd:TSystem"/>
-                                </xs:choice>
-                            </xs:sequence>
-                        </xs:complexType>
-                    </xs:element>
-                    <xs:element name="Connections" minOccurs="0">
-                        <xs:complexType>
-                            <xs:sequence>
-                                <xs:element name="Connection" maxOccurs="unbounded">
-                                    <xs:annotation>
-                                        <xs:documentation xml:lang="en">
+		</xs:annotation>
+		<xs:complexContent>
+			<xs:extension base="ssd:TElement">
+				<xs:sequence>
+					<xs:element name="Elements" minOccurs="0">
+						<xs:complexType>
+							<xs:sequence>
+								<xs:choice maxOccurs="unbounded">
+									<xs:element name="Component" type="ssd:TComponent"/>
+									<xs:element name="SignalDictionaryReference" type="ssd:TSignalDictionaryReference"/>
+									<xs:element name="System" type="ssd:TSystem"/>
+								</xs:choice>
+							</xs:sequence>
+						</xs:complexType>
+					</xs:element>
+					<xs:element name="Connections" minOccurs="0">
+						<xs:complexType>
+							<xs:sequence>
+								<xs:element name="Connection" maxOccurs="unbounded">
+									<xs:annotation>
+										<xs:documentation xml:lang="en">
                                             This element specifies a connection between two connectors,
                                             either of the system or its directly contained elements.
                                             Note that connections between connectors on a system are
@@ -390,20 +371,20 @@
                                             must match, i.e. either both are input or both output or both
                                             parameter or both calculatedParameter.
                                         </xs:documentation>
-                                    </xs:annotation>
-                                    <xs:complexType>
-                                        <xs:sequence>
-                                            <xs:group ref="ssc:GTransformationChoice" minOccurs="0" maxOccurs="1">
-                                                <xs:annotation>
-                                                    <xs:documentation xml:lang="en">
+									</xs:annotation>
+									<xs:complexType>
+										<xs:sequence>
+											<xs:group ref="ssc:GTransformationChoice" minOccurs="0" maxOccurs="1">
+												<xs:annotation>
+													<xs:documentation xml:lang="en">
                                                         This optional element specifies a transformation that is to be applied to the
                                                         source value prior to its conveyance to the target.
                                                     </xs:documentation>
-                                                </xs:annotation>
-                                            </xs:group>
-                                            <xs:element name="ConnectionGeometry" minOccurs="0">
-                                                <xs:annotation>
-                                                    <xs:documentation xml:lang="en">
+												</xs:annotation>
+											</xs:group>
+											<xs:element name="ConnectionGeometry" minOccurs="0">
+												<xs:annotation>
+													<xs:documentation xml:lang="en">
                                                         This optional element defines the geometry information of the connection.
                                                         The start and end coordinates of the connection are derived automatically
                                                         through the coordinates of the corresponding connectors.  The only relevant
@@ -416,68 +397,68 @@
                                                         Note that x and y coordinates are in the coordinate system of the
                                                         enclosing system.
                                                     </xs:documentation>
-                                                </xs:annotation>
-                                                <xs:complexType>
-                                                    <xs:attribute name="pointsX" use="required">
-                                                        <xs:simpleType>
-                                                            <xs:list itemType="xs:double"/>
-                                                        </xs:simpleType>
-                                                    </xs:attribute>
-                                                    <xs:attribute name="pointsY" use="required">
-                                                        <xs:simpleType>
-                                                            <xs:list itemType="xs:double"/>
-                                                        </xs:simpleType>
-                                                    </xs:attribute>
-                                                </xs:complexType>
-                                            </xs:element>
-                                            <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
-                                        </xs:sequence>
-                                        <xs:attributeGroup ref="ssc:ABaseElement"/>
-                                        <xs:attribute name="startElement" type="xs:string" use="optional">
-                                            <xs:annotation>
-                                                <xs:documentation xml:lang="en">
+												</xs:annotation>
+												<xs:complexType>
+													<xs:attribute name="pointsX" use="required">
+														<xs:simpleType>
+															<xs:list itemType="xs:double"/>
+														</xs:simpleType>
+													</xs:attribute>
+													<xs:attribute name="pointsY" use="required">
+														<xs:simpleType>
+															<xs:list itemType="xs:double"/>
+														</xs:simpleType>
+													</xs:attribute>
+												</xs:complexType>
+											</xs:element>
+											<xs:group ref="ssc:GElementCommon"/>
+										</xs:sequence>
+										<xs:attributeGroup ref="ssc:ABaseElement"/>
+										<xs:attribute name="startElement" type="xs:string" use="optional">
+											<xs:annotation>
+												<xs:documentation xml:lang="en">
                                                     This attribute gives the name of the element that contains
                                                     the connector given as startConnector.  If the attribute
                                                     is elided, then the startConnector names a connector on
                                                     this system.
                                                 </xs:documentation>
-                                            </xs:annotation>
-                                        </xs:attribute>
-                                        <xs:attribute name="startConnector" type="xs:string" use="required">
-                                            <xs:annotation>
-                                                <xs:documentation xml:lang="en">
+											</xs:annotation>
+										</xs:attribute>
+										<xs:attribute name="startConnector" type="xs:string" use="required">
+											<xs:annotation>
+												<xs:documentation xml:lang="en">
                                                     This attribute gives the name of the connector that is
                                                     the start of the connection.  If startElement is not
                                                     supplied this indicates a connector on this system,
                                                     otherwise the connector is to be found on the given
                                                     element.
                                                 </xs:documentation>
-                                            </xs:annotation>
-                                        </xs:attribute>
-                                        <xs:attribute name="endElement" type="xs:string" use="optional">
-                                            <xs:annotation>
-                                                <xs:documentation xml:lang="en">
+											</xs:annotation>
+										</xs:attribute>
+										<xs:attribute name="endElement" type="xs:string" use="optional">
+											<xs:annotation>
+												<xs:documentation xml:lang="en">
                                                     This attribute gives the name of the element that contains
                                                     the connector given as endConnector.  If the attribute
                                                     is elided, then the endConnector names a connector on
                                                     this system.
                                                 </xs:documentation>
-                                            </xs:annotation>
-                                        </xs:attribute>
-                                        <xs:attribute name="endConnector" type="xs:string" use="required">
-                                            <xs:annotation>
-                                                <xs:documentation xml:lang="en">
+											</xs:annotation>
+										</xs:attribute>
+										<xs:attribute name="endConnector" type="xs:string" use="required">
+											<xs:annotation>
+												<xs:documentation xml:lang="en">
                                                     This attribute gives the name of the connector that is
                                                     the end of the connection.  If endElement is not
                                                     supplied this indicates a connector on this system,
                                                     otherwise the connector is to be found on the given
                                                     element.
                                                 </xs:documentation>
-                                            </xs:annotation>
-                                        </xs:attribute>
-                                        <xs:attribute name="suppressUnitConversion" type="xs:boolean" use="optional" default="false">
-                                            <xs:annotation>
-                                                <xs:documentation xml:lang="en">
+											</xs:annotation>
+										</xs:attribute>
+										<xs:attribute name="suppressUnitConversion" type="xs:boolean" use="optional" default="false">
+											<xs:annotation>
+												<xs:documentation xml:lang="en">
                                                     This attribute specifies whether automatic conversions between start
                                                     and end connector are performed using unit information potentially
                                                     available for both start and end definitions.  If this attribute is
@@ -489,17 +470,17 @@
                                                     is performed instead of any unit conversions, whereas otherwise the
                                                     linear transformation is performed in addition to any unit conversions.
                                                 </xs:documentation>
-                                            </xs:annotation>
-                                        </xs:attribute>
-                                    </xs:complexType>
-                                </xs:element>
-                            </xs:sequence>
-                        </xs:complexType>
-                    </xs:element>
-                    <xs:element name="SignalDictionaries" minOccurs="0" type="ssd:TSignalDictionaries"/>
-                    <xs:element name="SystemGeometry" minOccurs="0">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
+											</xs:annotation>
+										</xs:attribute>
+									</xs:complexType>
+								</xs:element>
+							</xs:sequence>
+						</xs:complexType>
+					</xs:element>
+					<xs:element name="SignalDictionaries" type="ssd:TSignalDictionaries" minOccurs="0"/>
+					<xs:element name="SystemGeometry" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
                                 This optional element defines the extent of the system canvas. 
                                 (x1,y1) and (x2,y2) define the lower-left and upper-right 
                                 corner, respectively.
@@ -519,17 +500,17 @@
                                 is the respective coordinate of the sub-system when instantiated
                                 in the parent system after rotation.
                             </xs:documentation>
-                        </xs:annotation>
-                        <xs:complexType>
-                            <xs:attribute name="x1" type="xs:double" use="required"/>
-                            <xs:attribute name="y1" type="xs:double" use="required"/>
-                            <xs:attribute name="x2" type="xs:double" use="required"/>
-                            <xs:attribute name="y2" type="xs:double" use="required"/>
-                        </xs:complexType>
-                    </xs:element>
-                    <xs:element name="GraphicalElements" minOccurs="0">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
+						</xs:annotation>
+						<xs:complexType>
+							<xs:attribute name="x1" type="xs:double" use="required"/>
+							<xs:attribute name="y1" type="xs:double" use="required"/>
+							<xs:attribute name="x2" type="xs:double" use="required"/>
+							<xs:attribute name="y2" type="xs:double" use="required"/>
+						</xs:complexType>
+					</xs:element>
+					<xs:element name="GraphicalElements" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
                                 This optional element contains the set of purely graphical elements
                                 that are contained in the system, e.g. things like notes, which have no
                                 semantic impact on the system but aid in presentation of the system in
@@ -540,13 +521,13 @@
                                 in the future more elements might be added as needed for exchange of
                                 graphical information.
                             </xs:documentation>
-                        </xs:annotation>
-                        <xs:complexType>
-                            <xs:sequence>
-                                <xs:choice maxOccurs="unbounded">
-                                    <xs:element name="Note">
-                                        <xs:annotation>
-                                            <xs:documentation xml:lang="en">
+						</xs:annotation>
+						<xs:complexType>
+							<xs:sequence>
+								<xs:choice maxOccurs="unbounded">
+									<xs:element name="Note">
+										<xs:annotation>
+											<xs:documentation xml:lang="en">
                                                 This element defines a graphical note to be placed on the canvas of the
                                                 enclosing system.  It is sized using the attributes so that the coordinates
                                                 (x1,y1) and (x2,y2) define the positions of the lower-left and upper-right
@@ -559,33 +540,31 @@
                                                 or other means) to show the remainder of the note text.  Inside the text
                                                 attribute, newlines indicate paragraph breaks.
                                             </xs:documentation>
-                                        </xs:annotation>
-                                        <xs:complexType>
-                                            <xs:attribute name="x1" type="xs:double" use="required"/>
-                                            <xs:attribute name="y1" type="xs:double" use="required"/>
-                                            <xs:attribute name="x2" type="xs:double" use="required"/>
-                                            <xs:attribute name="y2" type="xs:double" use="required"/>
-                                            <xs:attribute name="text" type="xs:string" use="required"/>
-                                        </xs:complexType>
-                                    </xs:element>
-                                </xs:choice>
-                            </xs:sequence>
-                        </xs:complexType>
-                    </xs:element>
-                    <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
-                </xs:sequence>
-            </xs:extension>
-        </xs:complexContent>
-    </xs:complexType>
-
-    <xs:complexType name="TConnectors">
-        <xs:sequence>
-            <xs:element name="Connector" maxOccurs="unbounded">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:group ref="ssc:GTypeChoice" minOccurs="0">
-                            <xs:annotation>
-                                <xs:documentation xml:lang="en">
+										</xs:annotation>
+										<xs:complexType>
+											<xs:attribute name="x1" type="xs:double" use="required"/>
+											<xs:attribute name="y1" type="xs:double" use="required"/>
+											<xs:attribute name="x2" type="xs:double" use="required"/>
+											<xs:attribute name="y2" type="xs:double" use="required"/>
+											<xs:attribute name="text" type="xs:string" use="required"/>
+										</xs:complexType>
+									</xs:element>
+								</xs:choice>
+							</xs:sequence>
+						</xs:complexType>
+					</xs:element>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="TConnectors">
+		<xs:sequence>
+			<xs:element name="Connector" maxOccurs="unbounded">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:group ref="ssc:GTypeChoice" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">
                                     This element gives the type of the connector.
                                     
                                     If a type is not supplied, the type is determined through
@@ -597,11 +576,11 @@
                                     differs from the type of the underlying FMU variable this
                                     constitutes an error.
                                 </xs:documentation>
-                            </xs:annotation>
-                        </xs:group>
-                        <xs:element name="ConnectorGeometry" minOccurs="0">
-                            <xs:annotation>
-                                <xs:documentation xml:lang="en">
+							</xs:annotation>
+						</xs:group>
+						<xs:element name="ConnectorGeometry" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">
                                     This optional element gives the geometry information of the connector.
                                     Note that x and y coordinates are in a special coordinate system, where
                                     0,0 is the lower-left corner of the component/system, and 1,1 is the
@@ -613,18 +592,18 @@
                                     determined by the ElementGeometry for the outside view, and the
                                     one determined by SystemGeometry for the inside view.
                                 </xs:documentation>
-                            </xs:annotation>
-                            <xs:complexType>
-                                <xs:attribute name="x" type="xs:double" use="required"/>
-                                <xs:attribute name="y" type="xs:double" use="required"/>
-                            </xs:complexType>
-                        </xs:element>
-                        <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
-                    </xs:sequence>
-                    <xs:attributeGroup ref="ssc:ABaseElement"/>
-                    <xs:attribute name="name" type="xs:string" use="required">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
+							</xs:annotation>
+							<xs:complexType>
+								<xs:attribute name="x" type="xs:double" use="required"/>
+								<xs:attribute name="y" type="xs:double" use="required"/>
+							</xs:complexType>
+						</xs:element>
+						<xs:group ref="ssc:GElementCommon"/>
+					</xs:sequence>
+					<xs:attributeGroup ref="ssc:ABaseElement"/>
+					<xs:attribute name="name" type="xs:string" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
                                 This attribute gives the connector a name, which
                                 shall be unique within the component or system and,
                                 for components, must match the name of a relevant 
@@ -637,11 +616,11 @@
                                 be present which are referenced in connections inside
                                 the SSD.
                             </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="kind" use="required">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="kind" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
                                 This attribute specifies the kind of the given connector,
                                 which indicates whether the connector is an input, an output,
                                 both (inout), a constant, a parameter, a calculated parameter
@@ -674,29 +653,28 @@
                                 This can be used for example to allow a connector to function as
                                 both an input and output within the same SignalDictionaryReference.
                             </xs:documentation>
-                        </xs:annotation>
-                        <xs:simpleType>
-                            <xs:restriction base="xs:string">
-                                <xs:enumeration value="input"/>
-                                <xs:enumeration value="output"/>
-                                <xs:enumeration value="parameter"/>
-                                <xs:enumeration value="calculatedParameter"/>
-                                <xs:enumeration value="structuralParameter"/>
-                                <xs:enumeration value="constant"/>
-                                <xs:enumeration value="inout"/>
-                            </xs:restriction>
-                        </xs:simpleType>
-                    </xs:attribute>
-                </xs:complexType>
-            </xs:element>
-        </xs:sequence>
-    </xs:complexType>
-
-    <xs:complexType name="TParameterBindings">
-        <xs:sequence maxOccurs="unbounded">
-            <xs:element name="ParameterBinding">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="xs:string">
+								<xs:enumeration value="input"/>
+								<xs:enumeration value="output"/>
+								<xs:enumeration value="parameter"/>
+								<xs:enumeration value="calculatedParameter"/>
+								<xs:enumeration value="structuralParameter"/>
+								<xs:enumeration value="constant"/>
+								<xs:enumeration value="inout"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TParameterBindings">
+		<xs:sequence maxOccurs="unbounded">
+			<xs:element name="ParameterBinding">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">
                         This provides a parameter binding for a component or system.  For FMU components this
                         allows the parametrization of the FMU's parameters and start values of other variables
                         with a parameter source (e.g. a parameter file).  Note that in this case the names
@@ -747,12 +725,12 @@
                         of the system.  Therefore they take priority over any of the existing parameter bindings
                         (for parameters with identical names).
                     </xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element name="ParameterValues" minOccurs="0">
-                            <xs:annotation>
-                                <xs:documentation xml:lang="en">
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="ParameterValues" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">
                                     This optional element can be used to provide parameter values inline
                                     to the parameter binding, in which case the source attribute of the
                                     ParameterBinding element must be empty.
@@ -763,17 +741,17 @@
                                     MIME type (in that case there should be a layered specification that
                                     defines how embedding the content works for that MIME type).
                                 </xs:documentation>
-                            </xs:annotation>
-                            <xs:complexType>
-                                <xs:choice>
-                                    <xs:element ref="ssv:ParameterSet"/>
-                                    <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-                                </xs:choice>
-                            </xs:complexType>
-                        </xs:element>
-                        <xs:element name="ParameterMapping" minOccurs="0">
-                            <xs:annotation>
-                                <xs:documentation xml:lang="en">
+							</xs:annotation>
+							<xs:complexType>
+								<xs:choice>
+									<xs:element ref="ssv:ParameterSet"/>
+									<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+								</xs:choice>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="ParameterMapping" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">
                                     This element provides an optional parameter mapping, which specifies how
                                     the parameter names and values provided in the parameter source are to be
                                     mapped to the parameters of the component or system in question.  If no
@@ -792,17 +770,17 @@
                                     there should be a layered specification that defines how embedding the content
                                     works for that MIME type).
                                 </xs:documentation>
-                            </xs:annotation>
-                            <xs:complexType>
-                                <xs:choice>
-                                    <xs:element ref="ssm:ParameterMapping"/>
-                                    <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-                                </xs:choice>
-                                <xs:attributeGroup ref="ssc:ABaseElement"/>
-                                <xs:attribute name="type" type="xs:string" use="optional" default="application/x-ssp-parameter-mapping"/>
-                                <xs:attribute name="source" type="xs:anyURI" use="optional">
-                                    <xs:annotation>
-                                        <xs:documentation xml:lang="en">
+							</xs:annotation>
+							<xs:complexType>
+								<xs:choice>
+									<xs:element ref="ssm:ParameterMapping"/>
+									<xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+								</xs:choice>
+								<xs:attributeGroup ref="ssc:ABaseElement"/>
+								<xs:attribute name="type" type="xs:string" use="optional" default="application/x-ssp-parameter-mapping"/>
+								<xs:attribute name="source" type="xs:anyURI" use="optional">
+									<xs:annotation>
+										<xs:documentation xml:lang="en">
                                             This attribute indicates the source of the parameter mapping as a URI
                                             (cf. RFC 3986).  For purposes of the resolution of relative URIs
                                             the base URI is the URI of the SSD, if the sourcebase attribute
@@ -815,42 +793,42 @@
                                             inline as contents of the ParameterMapping element, which must be
                                             empty otherwise.
                                         </xs:documentation>
-                                    </xs:annotation>
-                                </xs:attribute>
-                                <xs:attribute name="sourceBase" use="optional" default="SSD">
-                                    <xs:annotation>
-                                        <xs:documentation xml:lang="en">
+									</xs:annotation>
+								</xs:attribute>
+								<xs:attribute name="sourceBase" use="optional" default="SSD">
+									<xs:annotation>
+										<xs:documentation xml:lang="en">
                                             Defines the base the source URI is resolved against:  If the attribute
                                             is missing or is specified as SSD, the source is resolved against the
                                             URI of the SSD, if the attribute is specified as component the URI is
                                             resolved against the (resolved) URI of the component source.
                                         </xs:documentation>
-                                    </xs:annotation>
-                                    <xs:simpleType>
-                                        <xs:restriction base="xs:string">
-                                            <xs:enumeration value="SSD"/>
-                                            <xs:enumeration value="component"/>
-                                        </xs:restriction>
-                                    </xs:simpleType>
-                                </xs:attribute>
-                            </xs:complexType>
-                        </xs:element>
-                        <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
-                    </xs:sequence>
-                    <xs:attributeGroup ref="ssc:ABaseElement"/>
-                    <xs:attribute name="type" type="xs:string" use="optional" default="application/x-ssp-parameter-set">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
+									</xs:annotation>
+									<xs:simpleType>
+										<xs:restriction base="xs:string">
+											<xs:enumeration value="SSD"/>
+											<xs:enumeration value="component"/>
+										</xs:restriction>
+									</xs:simpleType>
+								</xs:attribute>
+							</xs:complexType>
+						</xs:element>
+						<xs:group ref="ssc:GElementCommon"/>
+					</xs:sequence>
+					<xs:attributeGroup ref="ssc:ABaseElement"/>
+					<xs:attribute name="type" type="xs:string" use="optional" default="application/x-ssp-parameter-set">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
                                 This attribute specifies the MIME type of the parameter source, which defaults
                                 to application/x-ssp-parameter-set to indicate the SSP parameter set file format.
                                 No further types are currently defined, but can of course be added at a later
                                 date, e.g. for pre-existing parameter file formats, like CDF, etc.
                             </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="source" type="xs:anyURI" use="optional">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="source" type="xs:anyURI" use="optional">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
                                 This attribute indicates the source of the parameters as a URI
                                 (cf. RFC 3986).  For purposes of the resolution of relative URIs
                                 the base URI is the URI of the SSD, if the sourcebase attribute
@@ -866,27 +844,27 @@
                                 inline as contents of a ParameterValues element, which must not be
                                 present otherwise.
                             </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="sourceBase" use="optional" default="SSD">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="sourceBase" use="optional" default="SSD">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
                                 Defines the base the source URI is resolved against:  If the attribute
                                 is missing or is specified as SSD, the source is resolved against the
                                 URI of the SSD, if the attribute is specified as component the URI is
                                 resolved against the (resolved) URI of the component source.
                             </xs:documentation>
-                        </xs:annotation>
-                        <xs:simpleType>
-                            <xs:restriction base="xs:string">
-                                <xs:enumeration value="SSD"/>
-                                <xs:enumeration value="component"/>
-                            </xs:restriction>
-                        </xs:simpleType>
-                    </xs:attribute>
-                    <xs:attribute name="prefix" type="xs:string" use="optional" default="">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="xs:string">
+								<xs:enumeration value="SSD"/>
+								<xs:enumeration value="component"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="prefix" type="xs:string" use="optional" default="">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
                                 Defines the optional prefix for name resolution and mapping purposes
                                 for this binding.  If this attribute is empty or not supplied no
                                 prefix is used for name resolution and mapping, otherwise the specified
@@ -898,33 +876,32 @@
                                 as a prefix on the binding, thus causing all parameter names in the parameter
                                 set to be treated as if they were specified with proper hierarchical names.
                             </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:complexType>
-            </xs:element>
-        </xs:sequence>
-    </xs:complexType>
-    
-    <xs:complexType name="TDefaultExperiment">
-        <xs:annotation>
-            <xs:documentation xml:lang="en">
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TDefaultExperiment">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">
                 The attributes of this element, if present, specify reasonable default values
                 for running an experiment of the given system.  Any tool is free to ignore this
                 information.
             </xs:documentation>
-        </xs:annotation>
-        <xs:sequence>
-            <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
-        </xs:sequence>
-        <xs:attribute name="startTime" type="xs:double" use="optional">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">Default start time of simulation</xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="stopTime" type="xs:double" use="optional">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">Default stop time of simulation</xs:documentation>
-            </xs:annotation>            
-        </xs:attribute>
-    </xs:complexType>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Annotations" type="ssc:TAnnotations" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="startTime" type="xs:double" use="optional">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">Default start time of simulation</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="stopTime" type="xs:double" use="optional">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">Default stop time of simulation</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
 </xs:schema>

--- a/schema/SystemStructureParameterMapping.xsd
+++ b/schema/SystemStructureParameterMapping.xsd
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
-    xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
-    xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
-    targetNamespace="http://ssp-standard.org/SSP1/SystemStructureParameterMapping">
-    <xs:annotation>
-        <xs:documentation xml:lang="en">
+<!-- Mit XMLSpy v2020 rel. 2 sp1 (x64) (http://www.altova.com) von  (eXXcellent solutions GmbH) bearbeitet -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" targetNamespace="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" elementFormDefault="qualified">
+	<xs:annotation>
+		<xs:documentation xml:lang="en">
             This is the normative XML Schema 1.0 schema for the MAP SSP
             SystemStructureParameterMapping 2.0 format.
             
@@ -40,67 +38,64 @@
             OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
             POSSIBILITY OF SUCH DAMAGE.
         </xs:documentation>
-    </xs:annotation>
-    
-    <xs:import namespace="http://ssp-standard.org/SSP1/SystemStructureCommon" schemaLocation="SystemStructureCommon.xsd"/>
-    
-    <xs:element name="ParameterMapping">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="MappingEntry" minOccurs="0" maxOccurs="unbounded" type="ssm:TMappingEntry"/>
-                <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
-            </xs:sequence>
-            <xs:attribute name="version" use="required">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
+	</xs:annotation>
+	<xs:import namespace="http://ssp-standard.org/SSP1/SystemStructureCommon" schemaLocation="SystemStructureCommon.xsd"/>
+	<xs:element name="ParameterMapping">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="MappingEntry" type="ssm:TMappingEntry" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:group ref="ssc:GElementCommon"/>
+			</xs:sequence>
+			<xs:attribute name="version" use="required">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">
                         Version of SSM format, 2.0-alpha for this release.
                     </xs:documentation>
-                </xs:annotation>
-                <xs:simpleType>
-                    <xs:restriction base="xs:normalizedString">
-                        <xs:pattern value="2[.][0-9]+(-.+)"/>
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:attribute>
-            <xs:attributeGroup ref="ssc:ABaseElement"/>
-            <xs:attributeGroup ref="ssc:ATopLevelMetaData"/>
-        </xs:complexType>
-    </xs:element>
-    
-    <xs:complexType name="TMappingEntry">
-        <xs:sequence>
-            <xs:group ref="ssc:GTransformationChoice" minOccurs="0" maxOccurs="1">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:normalizedString">
+						<xs:pattern value="2[.][0-9]+(-.+)"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attributeGroup ref="ssc:ABaseElement"/>
+			<xs:attributeGroup ref="ssc:ATopLevelMetaData"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="TMappingEntry">
+		<xs:sequence>
+			<xs:group ref="ssc:GTransformationChoice" minOccurs="0" maxOccurs="1">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">
                         This optional element specifies a transformation that is to be applied to
                         the parameter value prior to its application to its target parameter.
                     </xs:documentation>
-                </xs:annotation>
-            </xs:group>
-            <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
-        </xs:sequence>
-        <xs:attributeGroup ref="ssc:ABaseElement"/>
-        <xs:attribute name="source" type="xs:string" use="required">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
+				</xs:annotation>
+			</xs:group>
+			<xs:group ref="ssc:GElementCommon"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ssc:ABaseElement"/>
+		<xs:attribute name="source" type="xs:string" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
                     This attribute specifies the name of the parameter in the parameter source
                     that is to be mapped to a new name and/or provided with a transformation
                     in this mapping entry.
                 </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="target" type="xs:string" use="required">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="target" type="xs:string" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
                     This attribute specifies the name of the parameter in the system or
                     component that is to be parametrized, i.e. that is the target of this
                     mapping entry.
                 </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="suppressUnitConversion" type="xs:boolean" use="optional" default="false">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="suppressUnitConversion" type="xs:boolean" use="optional" default="false">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
                     This attribute specifies whether automatic conversions between start
                     and end connector are performed using unit information potentially
                     available for both start and end definitions.  If this attribute is
@@ -112,8 +107,7 @@
                     is performed instead of any unit conversions, whereas otherwise the
                     linear transformation is performed in addition to any unit conversions.
                 </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:complexType>
-   
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
 </xs:schema>

--- a/schema/SystemStructureParameterValues.xsd
+++ b/schema/SystemStructureParameterValues.xsd
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
-    xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
-    xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
-    targetNamespace="http://ssp-standard.org/SSP1/SystemStructureParameterValues">
-    <xs:annotation>
-        <xs:documentation xml:lang="en">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" targetNamespace="http://ssp-standard.org/SSP1/SystemStructureParameterValues" elementFormDefault="qualified">
+	<xs:annotation>
+		<xs:documentation xml:lang="en">
             This is the normative XML Schema 1.0 schema for the MAP SSP
             SystemStructureParameterValues 2.0 format.
                         
@@ -40,248 +37,244 @@
             OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
             POSSIBILITY OF SUCH DAMAGE.
         </xs:documentation>
-    </xs:annotation>
-    
-    <xs:import namespace="http://ssp-standard.org/SSP1/SystemStructureCommon" schemaLocation="SystemStructureCommon.xsd"/>
-    
-    <xs:element name="ParameterSet">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="Parameters" type="ssv:TParameters"/>
-                <xs:element name="Enumerations" minOccurs="0" type="ssc:TEnumerations"/>
-                <xs:element name="Units" minOccurs="0" type="ssc:TUnits"/>
-                <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
-            </xs:sequence>
-            <xs:attribute name="version" use="required">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
+	</xs:annotation>
+	<xs:import namespace="http://ssp-standard.org/SSP1/SystemStructureCommon" schemaLocation="SystemStructureCommon.xsd"/>
+	<xs:element name="ParameterSet">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="Parameters" type="ssv:TParameters"/>
+				<xs:element name="Enumerations" type="ssc:TEnumerations" minOccurs="0"/>
+				<xs:element name="Units" type="ssc:TUnits" minOccurs="0"/>
+				<xs:group ref="ssc:GElementCommon"/>
+			</xs:sequence>
+			<xs:attribute name="version" use="required">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">
                         Version of SSV format, 2.0-alpha for this release.
                     </xs:documentation>
-                </xs:annotation>
-                <xs:simpleType>
-                    <xs:restriction base="xs:normalizedString">
-                        <xs:pattern value="2[.][0-9]+(-.+)"/>
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:attribute>
-            <xs:attributeGroup ref="ssc:ABaseElement"/>
-            <xs:attribute name="name" type="xs:string" use="required">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:normalizedString">
+						<xs:pattern value="2[.][0-9]+(-.+)"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attributeGroup ref="ssc:ABaseElement"/>
+			<xs:attribute name="name" type="xs:string" use="required">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">
                         Name of the Parameter Set.
                     </xs:documentation>
-                </xs:annotation>
-            </xs:attribute>
-            <xs:attributeGroup ref="ssc:ATopLevelMetaData"/>
-        </xs:complexType>
-    </xs:element>
-        
-    <xs:complexType name="TParameters">
-        <xs:sequence>
-            <xs:element name="Parameter" minOccurs="0" maxOccurs="unbounded" type="ssv:TParameter"/>
-        </xs:sequence>
-    </xs:complexType>
-        
-    <xs:complexType name="TParameter">
-        <xs:sequence>
-            <xs:choice>
-                <xs:element name="Real">
-                    <xs:complexType>
-                        <xs:attribute name="value" type="xs:double" use="required">
-                            <xs:annotation>
-                                <xs:documentation xml:lang="en">
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attributeGroup ref="ssc:ATopLevelMetaData"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="TParameters">
+		<xs:sequence>
+			<xs:element name="Parameter" type="ssv:TParameter" minOccurs="0" maxOccurs="unbounded"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TParameter">
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="Real">
+					<xs:complexType>
+						<xs:attribute name="value" type="xs:double" use="required">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">
                                     This attribute gives the value of the parameter.
                                 </xs:documentation>
-                            </xs:annotation>
-                        </xs:attribute>
-                        <xs:attribute name="unit" type="xs:string" use="optional">
-                            <xs:annotation>
-                                <xs:documentation xml:lang="en">
+							</xs:annotation>
+						</xs:attribute>
+						<xs:attribute name="unit" type="xs:string" use="optional">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">
                                     This attribute gives the unit of the parameter value and must
                                     reference one of the unit definitions provided in the Units
                                     element of the enclosing file.
                                 </xs:documentation>
-                            </xs:annotation>
-                        </xs:attribute>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="Float64">
-                    <xs:complexType>
-                        <xs:attribute name="value" type="xs:double" use="required">
-                            <xs:annotation>
-                                <xs:documentation xml:lang="en">
+							</xs:annotation>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="Float64">
+					<xs:complexType>
+						<xs:attribute name="value" type="xs:double" use="required">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">
                                     This attribute gives the value of the parameter.
                                 </xs:documentation>
-                            </xs:annotation>
-                        </xs:attribute>
-                        <xs:attribute name="unit" type="xs:string" use="optional">
-                            <xs:annotation>
-                                <xs:documentation xml:lang="en">
+							</xs:annotation>
+						</xs:attribute>
+						<xs:attribute name="unit" type="xs:string" use="optional">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">
                                     This attribute gives the unit of the parameter value and must
                                     reference one of the unit definitions provided in the Units
                                     element of the enclosing file.
                                 </xs:documentation>
-                            </xs:annotation>
-                        </xs:attribute>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="Float32">
-                    <xs:complexType>
-                        <xs:attribute name="value" type="xs:single" use="required">
-                            <xs:annotation>
-                                <xs:documentation xml:lang="en">
+							</xs:annotation>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="Float32">
+					<xs:complexType>
+						<xs:attribute name="value" type="xs:single" use="required">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">
                                     This attribute gives the value of the parameter.
                                 </xs:documentation>
-                            </xs:annotation>
-                        </xs:attribute>
-                        <xs:attribute name="unit" type="xs:string" use="optional">
-                            <xs:annotation>
-                                <xs:documentation xml:lang="en">
+							</xs:annotation>
+						</xs:attribute>
+						<xs:attribute name="unit" type="xs:string" use="optional">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">
                                     This attribute gives the unit of the parameter value and must
                                     reference one of the unit definitions provided in the Units
                                     element of the enclosing file.
                                 </xs:documentation>
-                            </xs:annotation>
-                        </xs:attribute>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="Integer">
-                    <xs:complexType>
-                        <xs:attribute name="value" type="xs:int" use="required">
-                            <xs:annotation>
-                                <xs:documentation xml:lang="en">
+							</xs:annotation>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="Integer">
+					<xs:complexType>
+						<xs:attribute name="value" type="xs:int" use="required">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">
                                     This attribute gives the value of the parameter.
                                 </xs:documentation>
-                            </xs:annotation>
-                        </xs:attribute>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="Int8">
-                    <xs:complexType>
-                        <xs:attribute name="value" type="xs:byte" use="required">
-                            <xs:annotation>
-                                <xs:documentation xml:lang="en">
+							</xs:annotation>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="Int8">
+					<xs:complexType>
+						<xs:attribute name="value" type="xs:byte" use="required">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">
                                     This attribute gives the value of the parameter.
                                 </xs:documentation>
-                            </xs:annotation>
-                        </xs:attribute>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="UInt8">
-                    <xs:complexType>
-                        <xs:attribute name="value" type="xs:unsignedByte" use="required">
-                            <xs:annotation>
-                                <xs:documentation xml:lang="en">
+							</xs:annotation>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="UInt8">
+					<xs:complexType>
+						<xs:attribute name="value" type="xs:unsignedByte" use="required">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">
                                     This attribute gives the value of the parameter.
                                 </xs:documentation>
-                            </xs:annotation>
-                        </xs:attribute>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="Int16">
-                    <xs:complexType>
-                        <xs:attribute name="value" type="xs:short" use="required">
-                            <xs:annotation>
-                                <xs:documentation xml:lang="en">
+							</xs:annotation>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="Int16">
+					<xs:complexType>
+						<xs:attribute name="value" type="xs:short" use="required">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">
                                     This attribute gives the value of the parameter.
                                 </xs:documentation>
-                            </xs:annotation>
-                        </xs:attribute>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="UInt16">
-                    <xs:complexType>
-                        <xs:attribute name="value" type="xs:unsignedShort" use="required">
-                            <xs:annotation>
-                                <xs:documentation xml:lang="en">
+							</xs:annotation>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="UInt16">
+					<xs:complexType>
+						<xs:attribute name="value" type="xs:unsignedShort" use="required">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">
                                     This attribute gives the value of the parameter.
                                 </xs:documentation>
-                            </xs:annotation>
-                        </xs:attribute>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="Int32">
-                    <xs:complexType>
-                        <xs:attribute name="value" type="xs:int" use="required">
-                            <xs:annotation>
-                                <xs:documentation xml:lang="en">
+							</xs:annotation>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="Int32">
+					<xs:complexType>
+						<xs:attribute name="value" type="xs:int" use="required">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">
                                     This attribute gives the value of the parameter.
                                 </xs:documentation>
-                            </xs:annotation>
-                        </xs:attribute>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="UInt32">
-                    <xs:complexType>
-                        <xs:attribute name="value" type="xs:unsignedInt" use="required">
-                            <xs:annotation>
-                                <xs:documentation xml:lang="en">
+							</xs:annotation>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="UInt32">
+					<xs:complexType>
+						<xs:attribute name="value" type="xs:unsignedInt" use="required">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">
                                     This attribute gives the value of the parameter.
                                 </xs:documentation>
-                            </xs:annotation>
-                        </xs:attribute>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="Int64">
-                    <xs:complexType>
-                        <xs:attribute name="value" type="xs:long" use="required">
-                            <xs:annotation>
-                                <xs:documentation xml:lang="en">
+							</xs:annotation>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="Int64">
+					<xs:complexType>
+						<xs:attribute name="value" type="xs:long" use="required">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">
                                     This attribute gives the value of the parameter.
                                 </xs:documentation>
-                            </xs:annotation>
-                        </xs:attribute>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="UInt64">
-                    <xs:complexType>
-                        <xs:attribute name="value" type="xs:unsignedLong" use="required">
-                            <xs:annotation>
-                                <xs:documentation xml:lang="en">
+							</xs:annotation>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="UInt64">
+					<xs:complexType>
+						<xs:attribute name="value" type="xs:unsignedLong" use="required">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">
                                     This attribute gives the value of the parameter.
                                 </xs:documentation>
-                            </xs:annotation>
-                        </xs:attribute>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="Boolean">
-                    <xs:complexType>
-                        <xs:attribute name="value" type="xs:boolean" use="required">
-                            <xs:annotation>
-                                <xs:documentation xml:lang="en">
+							</xs:annotation>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="Boolean">
+					<xs:complexType>
+						<xs:attribute name="value" type="xs:boolean" use="required">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">
                                     This attribute gives the value of the parameter.
                                 </xs:documentation>
-                            </xs:annotation>
-                        </xs:attribute>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="String">
-                    <xs:complexType>
-                        <xs:attribute name="value" type="xs:string" use="required">
-                            <xs:annotation>
-                                <xs:documentation xml:lang="en">
+							</xs:annotation>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="String">
+					<xs:complexType>
+						<xs:attribute name="value" type="xs:string" use="required">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">
                                     This attribute gives the value of the parameter.
                                 </xs:documentation>
-                            </xs:annotation>
-                        </xs:attribute>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="Enumeration">
-                    <xs:complexType>
-                        <xs:attribute name="value" type="xs:string" use="required">
-                            <xs:annotation>
-                                <xs:documentation xml:lang="en">
+							</xs:annotation>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="Enumeration">
+					<xs:complexType>
+						<xs:attribute name="value" type="xs:string" use="required">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">
                                     This attribute gives the value of the parameter as 
                                     the enumeration item name.  Note that the actual
                                     numeric value this value is mapped to at run time
                                     will depend on the item mapping of the enumeration
                                     type of the variables being parameterized.
                                 </xs:documentation>
-                            </xs:annotation>
-                        </xs:attribute>
-                        <xs:attribute name="name" type="xs:string" use="optional">
-                            <xs:annotation>
-                                <xs:documentation xml:lang="en">
+							</xs:annotation>
+						</xs:attribute>
+						<xs:attribute name="name" type="xs:string" use="optional">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">
                                     This attribute specifies the name of the enumeration
                                     which references into the set of defined enumerations
                                     of the system structure description, as contained in
@@ -297,15 +290,15 @@
                                     that information for user interface purposes, and/or
                                     for additional consistency checking. 
                                 </xs:documentation>
-                            </xs:annotation>
-                        </xs:attribute>
-                    </xs:complexType>
-                </xs:element>
-                <xs:element name="Binary">
-                    <xs:complexType>
-                        <xs:attribute name="mime-type" type="xs:string" default="application/octet-stream">
-                            <xs:annotation>
-                                <xs:documentation xml:lang="en">
+							</xs:annotation>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="Binary">
+					<xs:complexType>
+						<xs:attribute name="mime-type" type="xs:string" default="application/octet-stream">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">
                                     This optional attribute specifies the MIME type of the
                                     underlying binary data, which defaults to the non-specific
                                     application/octet-stream type.  This information can be
@@ -317,30 +310,29 @@
                                     ensure only compatible binary connectors/parameters are
                                     connected.
                                 </xs:documentation>
-                            </xs:annotation>
-                        </xs:attribute>
-                        <xs:attribute name="value" type="xs:hexBinary" use="required">
-                            <xs:annotation>
-                                <xs:documentation xml:lang="en">
+							</xs:annotation>
+						</xs:attribute>
+						<xs:attribute name="value" type="xs:hexBinary" use="required">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">
                                     This attribute gives the value of the parameter as a
                                     hex encoded binary value.
                                 </xs:documentation>
-                            </xs:annotation>
-                        </xs:attribute>
-                    </xs:complexType>
-                </xs:element>
-            </xs:choice>
-            <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
-        </xs:sequence>
-        <xs:attributeGroup ref="ssc:ABaseElement"/>
-        <xs:attribute name="name" type="xs:string" use="required">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
+							</xs:annotation>
+						</xs:attribute>
+					</xs:complexType>
+				</xs:element>
+			</xs:choice>
+			<xs:group ref="ssc:GElementCommon"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ssc:ABaseElement"/>
+		<xs:attribute name="name" type="xs:string" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
                     This attribute specifies the name of the parameter in the parameter set,
                     which must be unique within in the parameter set.
                 </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:complexType>
-     
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
 </xs:schema>

--- a/schema/SystemStructureSignalDictionary.xsd
+++ b/schema/SystemStructureSignalDictionary.xsd
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
-    xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
-    xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
-    targetNamespace="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary">
-    <xs:annotation>
-        <xs:documentation xml:lang="en">
+<!-- Mit XMLSpy v2020 rel. 2 sp1 (x64) (http://www.altova.com) von  (eXXcellent solutions GmbH) bearbeitet -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" targetNamespace="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" elementFormDefault="qualified">
+	<xs:annotation>
+		<xs:documentation xml:lang="en">
             This is the normative XML Schema 1.0 schema for the MAP SSP
             SystemStructureSignalDictionary 2.0 format.
             
@@ -40,49 +38,45 @@
             OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
             POSSIBILITY OF SUCH DAMAGE.
         </xs:documentation>
-    </xs:annotation>
-    
-    <xs:import namespace="http://ssp-standard.org/SSP1/SystemStructureCommon" schemaLocation="SystemStructureCommon.xsd"/>
-    
-    <xs:element name="SignalDictionary">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="DictionaryEntry" minOccurs="0" maxOccurs="unbounded" type="ssb:TDictionaryEntry"/>
-                <xs:element name="Enumerations" minOccurs="0" type="ssc:TEnumerations"/>
-                <xs:element name="Units" minOccurs="0" type="ssc:TUnits"/>
-                <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
-            </xs:sequence>
-            <xs:attribute name="version" use="required">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
+	</xs:annotation>
+	<xs:import namespace="http://ssp-standard.org/SSP1/SystemStructureCommon" schemaLocation="SystemStructureCommon.xsd"/>
+	<xs:element name="SignalDictionary">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="DictionaryEntry" type="ssb:TDictionaryEntry" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element name="Enumerations" type="ssc:TEnumerations" minOccurs="0"/>
+				<xs:element name="Units" type="ssc:TUnits" minOccurs="0"/>
+				<xs:group ref="ssc:GElementCommon"/>
+			</xs:sequence>
+			<xs:attribute name="version" use="required">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">
                         Version of SSB format, 2.0-alpha for this release.
                     </xs:documentation>
-                </xs:annotation>
-                <xs:simpleType>
-                    <xs:restriction base="xs:normalizedString">
-                        <xs:pattern value="2[.][0-9]+(-.+)"/>
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:attribute>
-            <xs:attributeGroup ref="ssc:ABaseElement"/>
-            <xs:attributeGroup ref="ssc:ATopLevelMetaData"/>
-        </xs:complexType>
-    </xs:element>
-    
-    <xs:complexType name="TDictionaryEntry">
-        <xs:sequence>
-            <xs:group ref="ssc:GTypeChoice"/>
-            <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
-        </xs:sequence>
-        <xs:attributeGroup ref="ssc:ABaseElement"/>
-        <xs:attribute name="name" use="required">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:normalizedString">
+						<xs:pattern value="2[.][0-9]+(-.+)"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attributeGroup ref="ssc:ABaseElement"/>
+			<xs:attributeGroup ref="ssc:ATopLevelMetaData"/>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="TDictionaryEntry">
+		<xs:sequence>
+			<xs:group ref="ssc:GTypeChoice"/>
+			<xs:group ref="ssc:GElementCommon"/>
+		</xs:sequence>
+		<xs:attributeGroup ref="ssc:ABaseElement"/>
+		<xs:attribute name="name" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
                     This attribute gives the dictionary entry a name, which
                     shall be unique within the signal dictionary.
                 </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:complexType>
-       
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
 </xs:schema>


### PR DESCRIPTION
Adds support fro srmd classifications via an GElementCommont group that wraps annotations and classifications.
Therefore srmd classifications can be used with all entities that are annotatable.