### PR TITLE
Dag bruck patch modelica

### DIFF
--- a/docs/5___ssd.adoc
+++ b/docs/5___ssd.adoc
@@ -174,8 +174,7 @@ When Modelica models are represeented in SSP, built-in input and output connecto
 Modelica connectors of more advanced types are mapped the same way as Modelica component models.
 
 * The connector type is ssc:Binary.
-* The connector source attribute contains the full path of the Modelica model.
-* The media type is "text/x-modelica".
+* The media type is "text/x-modelica" and the "path" attribute designates the path of the Modleica connector..
 * Acausal Modelica connector types are in SSP of kind="acausal".
 
 The dimensionality of the Connector is given by the presence of one or more Dimension elements.
@@ -198,7 +197,6 @@ If defined, this ConnectorGeometry overrides any ConnectorGeometry of a System i
 |Attribute |Description
 |x |Required attribute giving the x coordinate of the connector inside the special coordinate system.
 |y |Required attribute giving the y coordinate of the connector inside the special coordinate system.
-|rotation |Optional attribute giving the counter-clockwise rotation around (x, y). The default value is 0 (zero).
 |===
 
 [ _Graphical example for a ConnectorGeometry:_
@@ -578,6 +576,7 @@ For all connections of an element connector of type `Clock` to a system connecto
 |System |parameter |System |local
 |System |input |System |output
 |System |input |System |local
+|System|acausal|System|acausal
 |System |structuralParameter |Element |structuralParameter
 |System |structuralParameter |Element |parameter
 |System |structuralParameter |Element |input
@@ -587,6 +586,7 @@ For all connections of an element connector of type `Clock` to a system connecto
 |System |parameter |Element |inout
 |System |input |Element |input
 |System |input |Element |inout
+|System|acausal|Element|acausal
 |Element |constant |Element |structuralParameter
 |Element |constant |Element |parameter
 |Element |constant |Element |input
@@ -599,6 +599,7 @@ For all connections of an element connector of type `Clock` to a system connecto
 |Element |local  |Element |input
 |Element |local  |Element |inout
 |Element |inout |Element |input
+|Element|acausal|Element|acausal
 |Element |constant |System |constant
 |Element |constant |System |calculatedParameter
 |Element |constant |System |output
@@ -612,6 +613,7 @@ For all connections of an element connector of type `Clock` to a system connecto
 |Element |local  |System |local
 |Element |inout |System |output
 |Element |inout |System |local
+|Element|acausal|System|acausal
 |===
 
 The following XML child elements are specified for the Connection element:
@@ -775,6 +777,8 @@ A component is an atomic element of a system (i.e. its internal structure is not
 |type |Optional attribute giving the MIME type of the component, which defaults to `application/x-fmu-sharedlibrary` to indicate the type of the component.
 Valid further types are `application/x-ssp-definition` for system structure description files, `application/x-ssp-package` for system structure package files, and `text/x-modelica` for Modelica models.
 No further types are currently defined.
+For type `text/x-modelica`, a media type parameter `path` specifies the full path of the Modelica class.
+{empty}[ _Example: `type="text/x-modelica; path=Modelica.Mechanics.Rotational.Interface.Flange_A"`._ ]
 |source a|
 Optional attribute indicating the source of the component as a URI (cf. RFC 3986).
 For purposes of the resolution of relative URIs the base URI is the URI of the SSD.
@@ -791,7 +795,6 @@ This mechanism can be used to instantiate an embedded system definition multiple
 
 Note that implementations are only *REQUIRED* to support relative URIs as specified above, and that especially relative URIs that move beyond the baseURI (i.e. go up a level via `..`) are *not required* to be supported by implementations, and are in fact often not supported for security or other reasons.
 Implementations are also *not required* to support any absolute URIs and any specific URI schemes, but are of course allowed to support any and all kinds of URIs where this is considered useful.
-One example is the use of the `modelica:` URI scheme to designate a model in the namespace of a Modelica environment.
 
 If the source attribute is missing, this indicates that there is no provided source for the component, indicating a simulation architecture design without complete executable implementation.
 Implementations *CAN* take any specified type attribute into account when handling such components.

--- a/docs/5___ssd.adoc
+++ b/docs/5___ssd.adoc
@@ -119,7 +119,7 @@ Note that there is no requirement that connectors have to be present for all var
 At least those connectors *MUST* be present which are referenced in connections inside the SSD.
 
 |kind a|
-This attribute specifies the kind of the given connector, which indicates whether the connector is an input, an output, both (inout), a local variable, a constant, a parameter, a calculated parameter (i.e. a parameter that is calculated by the component during initialization), or a structural parameter (i.e. a parameter that can be set during (re-)configuration mode).
+This attribute specifies the kind of the given connector, which indicates whether the connector is an input, an output, both (inout), acausal (in e.g. Modelica), a local variable, a constant, a parameter, a calculated parameter (i.e. a parameter that is calculated by the component during initialization), or a structural parameter (i.e. a parameter that can be set during (re-)configuration mode).
 
 For components this *MUST* match the related kind of the underlying component implementation.
 For referenced FMUs it *MUST* match the combination of variability and causality:
@@ -156,6 +156,28 @@ Boolean / String / Enumeration / Binary / Clock |Exactly one of these elements *
 
 The type of the Connector is identified by the presence of one of the XML child elements Real, Float64, Float32, Integer, Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Boolean, String, Enumeration, Binary, or Clock.
 
+When Modelica models are represeented in SSP, built-in input and output connectors shall be mapped as follows.
+
+[width="100%",cols="25%,25%,50%",options="header",]
+|===
+|Modelica Type |SSP Type |SSP Kind
+|RealInput |ssc:Real |input
+|RealOutput |ssc:Real |output
+|IntegerInput |ssc:Integer |input
+|IntegerOutput |ssc:Integer |output
+|BooleanInput |ssc:Boolean |input
+|BooleanOutput |ssc:Boolean |output
+|StringInput |ssc:String |input
+|StringOutput |ssc:String |output
+|===
+
+Modelica connectors of more advanced types are mapped the same way as Modelica component models.
+
+* The connector type is ssc:Binary.
+* The connector source attribute contains the full path of the Modelica model.
+* The media type is "text/x-modelica".
+* Acausal Modelica connector types are in SSP of kind="acausal".
+
 The dimensionality of the Connector is given by the presence of one or more Dimension elements.
 
 The association of a connector to a clock is given by the presence of one or more Clock elements.
@@ -176,6 +198,7 @@ If defined, this ConnectorGeometry overrides any ConnectorGeometry of a System i
 |Attribute |Description
 |x |Required attribute giving the x coordinate of the connector inside the special coordinate system.
 |y |Required attribute giving the y coordinate of the connector inside the special coordinate system.
+|rotation |Optional attribute giving the counter-clockwise rotation around (x, y). The default value is 0 (zero).
 |===
 
 [ _Graphical example for a ConnectorGeometry:_
@@ -750,7 +773,7 @@ A component is an atomic element of a system (i.e. its internal structure is not
 |===
 |Attribute |Description
 |type |Optional attribute giving the MIME type of the component, which defaults to `application/x-fmu-sharedlibrary` to indicate the type of the component.
-Valid further types are `application/x-ssp-definition` for system structure description files, and `application/x-ssp-package` for system structure package files.
+Valid further types are `application/x-ssp-definition` for system structure description files, `application/x-ssp-package` for system structure package files, and `text/x-modelica` for Modelica models.
 No further types are currently defined.
 |source a|
 Optional attribute indicating the source of the component as a URI (cf. RFC 3986).
@@ -767,7 +790,8 @@ When the URI is a same-document URI with a fragment identifier, for example `#ot
 This mechanism can be used to instantiate an embedded system definition multiple times through reference to its definition element.
 
 Note that implementations are only *REQUIRED* to support relative URIs as specified above, and that especially relative URIs that move beyond the baseURI (i.e. go up a level via `..`) are *not required* to be supported by implementations, and are in fact often not supported for security or other reasons.
-Implementations are also *not required* to support any absolute URIs and any specific URI schemes (but are of course allowed to support any and all kinds of URIs where this is considered useful).
+Implementations are also *not required* to support any absolute URIs and any specific URI schemes, but are of course allowed to support any and all kinds of URIs where this is considered useful.
+One example is the use of the `modelica:` URI scheme to designate a model in the namespace of a Modelica environment.
 
 If the source attribute is missing, this indicates that there is no provided source for the component, indicating a simulation architecture design without complete executable implementation.
 Implementations *CAN* take any specified type attribute into account when handling such components.

--- a/docs/5___ssd.adoc
+++ b/docs/5___ssd.adoc
@@ -119,7 +119,7 @@ Note that there is no requirement that connectors have to be present for all var
 At least those connectors *MUST* be present which are referenced in connections inside the SSD.
 
 |kind a|
-This attribute specifies the kind of the given connector, which indicates whether the connector is an input, an output, both (inout), acausal (in e.g. Modelica), a local variable, a constant, a parameter, a calculated parameter (i.e. a parameter that is calculated by the component during initialization), or a structural parameter (i.e. a parameter that can be set during (re-)configuration mode).
+This attribute specifies the kind of the given connector, which indicates whether the connector is an input, an output, both (inout), unspecified, a local variable, a constant, a parameter, a calculated parameter (i.e. a parameter that is calculated by the component during initialization), or a structural parameter (i.e. a parameter that can be set during (re-)configuration mode).
 
 For components this *MUST* match the related kind of the underlying component implementation.
 For referenced FMUs it *MUST* match the combination of variability and causality:
@@ -137,6 +137,9 @@ However, if it is connected, the semantics are same as for an `output`.
 
 For SignalDictionaryReferences, the kind of a given connector can additionally be inout, which indicates that the semantics of the connector are derived from the connections going to the connector.
 This can be used for example to allow a connector to function as both an input and output within the same SignalDictionaryReference.
+
+Connectors of kind `unspecified` are used to define connectors for which the flow of information is either not yet specified, or is determined at runtime, for example for acausal connections of Modelica models.
+Such connectors can be connected to any other connector under the rules of the underlying modeling language.
 
 |===
 
@@ -156,7 +159,11 @@ Boolean / String / Enumeration / Binary / Clock |Exactly one of these elements *
 
 The type of the Connector is identified by the presence of one of the XML child elements Real, Float64, Float32, Integer, Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Boolean, String, Enumeration, Binary, or Clock.
 
-When Modelica models are represeented in SSP, built-in input and output connectors shall be mapped as follows.
+The dimensionality of the Connector is given by the presence of one or more Dimension elements.
+
+The association of a connector to a clock is given by the presence of one or more Clock elements.
+
+When Modelica models are represented in SSP, built-in input and output connectors shall be mapped as follows:
 
 [width="100%",cols="25%,25%,50%",options="header",]
 |===
@@ -171,15 +178,13 @@ When Modelica models are represeented in SSP, built-in input and output connecto
 |StringOutput |ssc:String |output
 |===
 
-Modelica connectors of more advanced types are mapped the same way as Modelica component models.
+Modelica connectors of more advanced types are currently mapped in the following way:
 
 * The connector type is ssc:Binary.
-* The media type is "text/x-modelica" and the "path" attribute designates the path of the Modleica connector..
-* Acausal Modelica connector types are in SSP of kind="acausal".
+* The media type is `text/x-modelica` and the `path` parameter of the media type designates the path of the Modelica connector.
+* Acausal Modelica connector types are mapped to connectors of kind unspecified.
 
-The dimensionality of the Connector is given by the presence of one or more Dimension elements.
-
-The association of a connector to a clock is given by the presence of one or more Clock elements.
+_[ Note that the current opaque mapping of more advanced types to Binary connectors is a temporary solution, and a more detailed mapping may be provided in future versions of the standard supporting more complex data types. ]_
 
 ===== ConnectorGeometry
 
@@ -551,6 +556,10 @@ Note that source and destination in the following table indicate the resulting d
 Implementations *MUST NOT* specify connections that are not of one of the allowed combinations in the following table.
 Implementations *MUST* ensure that data flow is specified unambiguously, including ensuring that not multiple connections with inbound data flow enter into a connector signifying an input, inout, parameter, or structuralParameter connector of an element, or a local, constant, calculatedParameter, or output connector of an enclosing system.
 
+For connectors of kind unspecified it is ultimately implementation-defined whether and how connections are allowed, as the exact semantics depend on the underlying modeling language.
+For the purposes of the following table, connectors of kind unspecified are treated as connectors of whatever kind is needed to make the connection allowed, i.e. they serve a wild-card role.
+The handling of conflicts that arise in transitive connections from conflicting wild-card assignments is implementation-defined.
+
 It is implementation-defined whether connections between connectors of different types are allowed, and to what extent conversions are performed.
 This includes type conversions that can be performed without data loss, e.g. converting from an output of type `Float32` to an input of type `Float64` or `Real`, as well as conversions that can potentially lead to data loss, e.g. converting from an output of type `Float64` to an input of type `Float32` or `Int8`.
 It is also implementation-defined how and whether any error-handling at runtime is performed in those cases.
@@ -576,7 +585,6 @@ For all connections of an element connector of type `Clock` to a system connecto
 |System |parameter |System |local
 |System |input |System |output
 |System |input |System |local
-|System|acausal|System|acausal
 |System |structuralParameter |Element |structuralParameter
 |System |structuralParameter |Element |parameter
 |System |structuralParameter |Element |input
@@ -586,7 +594,6 @@ For all connections of an element connector of type `Clock` to a system connecto
 |System |parameter |Element |inout
 |System |input |Element |input
 |System |input |Element |inout
-|System|acausal|Element|acausal
 |Element |constant |Element |structuralParameter
 |Element |constant |Element |parameter
 |Element |constant |Element |input
@@ -599,7 +606,6 @@ For all connections of an element connector of type `Clock` to a system connecto
 |Element |local  |Element |input
 |Element |local  |Element |inout
 |Element |inout |Element |input
-|Element|acausal|Element|acausal
 |Element |constant |System |constant
 |Element |constant |System |calculatedParameter
 |Element |constant |System |output
@@ -613,7 +619,6 @@ For all connections of an element connector of type `Clock` to a system connecto
 |Element |local  |System |local
 |Element |inout |System |output
 |Element |inout |System |local
-|Element|acausal|System|acausal
 |===
 
 The following XML child elements are specified for the Connection element:

--- a/schema/SystemStructureDescription.xsd
+++ b/schema/SystemStructureDescription.xsd
@@ -705,12 +705,12 @@
                     <xs:attribute name="kind" use="required">
                         <xs:annotation>
                             <xs:documentation xml:lang="en">
-                                This attribute specifies the kind of the given connector,
-                                which indicates whether the connector is an input, an output,
-                                both (inout), a local variable, a constant, a parameter, a
-                                calculated parameter (i.e. a parameter that is calculated by
-                                the component during initialization), or a structural parameter
-                                (i.e. a parameter that can be set during (re-)configuration mode).
+                                This attribute specifies the kind of the given connector, which
+                                indicates whether the connector is an input, an output, both
+                                (inout), unspecified, a local variable, a constant, a parameter,
+                                a calculated parameter (i.e. a parameter that is calculated by the
+                                component during initialization), or a structural parameter (i.e.
+                                a parameter that can be set during (re-)configuration mode).
                                 
                                 For components this must match the related kind of the underlying
                                 component implementation. For referenced FMUs it must match the
@@ -730,12 +730,23 @@
                                 variable must be output and the variability must be parameter. For
                                 connectors of kind constant the causality of the FMI 1.0 variable
                                 must be output and the variability must be constant.
+
+                                Connectors of kind `local` are used to define variables of the
+                                model element. Such a variable is not intended to be used for
+                                connections. However, if it is connected, the semantics are same as
+                                for an `output`.
                                 
                                 For SignalDictionaryReferences, the kind of a given connector can
                                 additionally be 'inout', which indicates that the semantics of the
                                 connector are derived from the connections going to the connector.
                                 This can be used for example to allow a connector to function as
                                 both an input and output within the same SignalDictionaryReference.
+
+                                Connectors of kind `unspecified` are used to define connectors for
+                                which the flow of information is either not yet specified, or is
+                                determined at runtime, for example for acausal connections of
+                                Modelica models. Such connectors can be connected to any other
+                                connector under the rules of the underlying modeling language.
                             </xs:documentation>
                         </xs:annotation>
                         <xs:simpleType>
@@ -748,6 +759,7 @@
                                 <xs:enumeration value="constant"/>
                                 <xs:enumeration value="local"/>
                                 <xs:enumeration value="inout"/>
+                                <xs:enumeration value="unspecified"/>
                             </xs:restriction>
                         </xs:simpleType>
                     </xs:attribute>

--- a/schema/SystemStructureDescription11.xsd
+++ b/schema/SystemStructureDescription11.xsd
@@ -702,12 +702,12 @@
                     <xs:attribute name="kind" use="required">
                         <xs:annotation>
                             <xs:documentation xml:lang="en">
-                                This attribute specifies the kind of the given connector,
-                                which indicates whether the connector is an input, an output,
-                                both (inout), a local variable, a constant, a parameter, a
-                                calculated parameter (i.e. a parameter that is calculated by
-                                the component during initialization), or a structural parameter
-                                (i.e. a parameter that can be set during (re-)configuration mode).
+                                This attribute specifies the kind of the given connector, which
+                                indicates whether the connector is an input, an output, both
+                                (inout), unspecified, a local variable, a constant, a parameter,
+                                a calculated parameter (i.e. a parameter that is calculated by the
+                                component during initialization), or a structural parameter (i.e.
+                                a parameter that can be set during (re-)configuration mode).
                                 
                                 For components this must match the related kind of the underlying
                                 component implementation. For referenced FMUs it must match the
@@ -727,12 +727,23 @@
                                 variable must be output and the variability must be parameter. For
                                 connectors of kind constant the causality of the FMI 1.0 variable
                                 must be output and the variability must be constant.
+
+                                Connectors of kind `local` are used to define variables of the
+                                model element. Such a variable is not intended to be used for
+                                connections. However, if it is connected, the semantics are same as
+                                for an `output`.
                                 
                                 For SignalDictionaryReferences, the kind of a given connector can
                                 additionally be 'inout', which indicates that the semantics of the
                                 connector are derived from the connections going to the connector.
                                 This can be used for example to allow a connector to function as
                                 both an input and output within the same SignalDictionaryReference.
+
+                                Connectors of kind `unspecified` are used to define connectors for
+                                which the flow of information is either not yet specified, or is
+                                determined at runtime, for example for acausal connections of
+                                Modelica models. Such connectors can be connected to any other
+                                connector under the rules of the underlying modeling language.
                             </xs:documentation>
                         </xs:annotation>
                         <xs:simpleType>
@@ -745,6 +756,7 @@
                                 <xs:enumeration value="constant"/>
                                 <xs:enumeration value="local"/>
                                 <xs:enumeration value="inout"/>
+                                <xs:enumeration value="unspecified"/>
                             </xs:restriction>
                         </xs:simpleType>
                     </xs:attribute>


### PR DESCRIPTION
Revised proposal for Modelica support in SSP. The significant changes are:
- Added the connector kind "acausal", allowing one acausal connector to connected to another,
- Added MIME-type "text/x-modelica" which has an additional attribute "path" which designates the Modelica class.

Compared to the previous proposal which was withdrawn:
- No source attribute for Binary types (replaced by attribute in MIME-type).
- No "rotational" attribute for connectors.