### PR TITLE
Update allowed version in schemas (#41)

### DIFF
--- a/docs/0___preamble.adoc
+++ b/docs/0___preamble.adoc
@@ -14,6 +14,7 @@ History / Road Map
 |Version |Date |Remarks
 |1.0 |2019-03-05 |First Public Release of SSP
 |1.0.1 |2022-07-25 |Public Release of SSP 1.0.1
+|2.0 | |Current Working Draft
 |===
 
 Please report issues that you find with this specification to map-ssp_projectlead@googlegroups.com.

--- a/docs/5___ssd.adoc
+++ b/docs/5___ssd.adoc
@@ -17,7 +17,7 @@ The root element of an SSD file *MUST* be a SystemStructureDescription element, 
 |Attribute |Description
 |version |This required attribute specifies the version of this specification that the system description conforms to.
 Only major and minor version number are included, the patch version number *MUST NOT* be included in this attribute.
-For the current release this *MUST* be 1.0.
+For the current release this *MUST* be either 1.0 or 2.0.
 |name |This required attribute provides a name, which can be used for purposes of presenting the system structure to the user, for example when selecting individual variant SSDs from an SSP.
 |===
 

--- a/docs/6___ssv.adoc
+++ b/docs/6___ssv.adoc
@@ -24,7 +24,7 @@ If the SSV is provided as a separate file, the root element *MUST* be a Paramete
 |Attribute |Description
 |version |This required attribute specifies the version of this specification that the parameter set conforms to.
 Only major and minor version number are included, the patch version number *MUST NOT* be included in this attribute.
-For the current release this *MUST* be 1.0.
+For the current release this *MUST* be either 1.0 or 2.0.
 |name |This required attribute provides a name which can be used for purposes of presenting the parameter set to the user.
 |===
 

--- a/docs/7___ssm.adoc
+++ b/docs/7___ssm.adoc
@@ -31,7 +31,7 @@ Implementations *CAN* map the same parameter to multiple names.
 |Attribute |Description
 |version |This required attribute specifies the version of this specification that the parameter mapping conforms to.
 Only major and minor version number are included, the patch version number *MUST NOT* be included in this attribute.
-For the current release this *MUST* be 1.0.
+For the current release this *MUST* be either 1.0 or 2.0.
 |===
 
 ==== MappingEntry

--- a/docs/8___ssb.adoc
+++ b/docs/8___ssb.adoc
@@ -25,7 +25,7 @@ This element describes a signal dictionary, which consists of one or more dictio
 |Attribute |Description
 |version |This required attribute specifies the version of this specification that the parameter mapping conforms to.
 Only major and minor version number are included, the patch version number *MUST NOT* be included in this attribute.
-For the current release this *MUST* be 1.0.
+For the current release this *MUST* be either 1.0 or 2.0.
 |===
 
 The following XML child elements are specified for the SignalDictionary element:

--- a/schema/SystemStructureDescription.xsd
+++ b/schema/SystemStructureDescription.xsd
@@ -57,11 +57,12 @@
             <xs:attribute name="version" use="required">
                 <xs:annotation>
                     <xs:documentation xml:lang="en">
-                        Version of SSD format, 2.0-alpha for this release.
+                        Version of SSD format, 1.0 or 2.0-alpha for this release.
                     </xs:documentation>
                 </xs:annotation>
                 <xs:simpleType>
                     <xs:restriction base="xs:normalizedString">
+                        <xs:pattern value="1[.]0"/>
                         <xs:pattern value="2[.][0-9]+(-.+)"/>
                     </xs:restriction>
                 </xs:simpleType>

--- a/schema/SystemStructureDescription11.xsd
+++ b/schema/SystemStructureDescription11.xsd
@@ -66,11 +66,12 @@
             <xs:attribute name="version" use="required">
                 <xs:annotation>
                     <xs:documentation xml:lang="en">
-                        Version of SSD format, 2.0-alpha for this release.
+                        Version of SSD format, 1.0 or 2.0-alpha for this release.
                     </xs:documentation>
                 </xs:annotation>
                 <xs:simpleType>
                     <xs:restriction base="xs:normalizedString">
+                        <xs:pattern value="1[.]0"/>
                         <xs:pattern value="2[.][0-9]+(-.+)"/>
                     </xs:restriction>
                 </xs:simpleType>

--- a/schema/SystemStructureParameterMapping.xsd
+++ b/schema/SystemStructureParameterMapping.xsd
@@ -54,11 +54,12 @@
             <xs:attribute name="version" use="required">
                 <xs:annotation>
                     <xs:documentation xml:lang="en">
-                        Version of SSM format, 2.0-alpha for this release.
+                        Version of SSM format, 1.0 or 2.0-alpha for this release.
                     </xs:documentation>
                 </xs:annotation>
                 <xs:simpleType>
                     <xs:restriction base="xs:normalizedString">
+                        <xs:pattern value="1[.]0"/>
                         <xs:pattern value="2[.][0-9]+(-.+)"/>
                     </xs:restriction>
                 </xs:simpleType>

--- a/schema/SystemStructureParameterValues.xsd
+++ b/schema/SystemStructureParameterValues.xsd
@@ -56,11 +56,12 @@
             <xs:attribute name="version" use="required">
                 <xs:annotation>
                     <xs:documentation xml:lang="en">
-                        Version of SSV format, 2.0-alpha for this release.
+                        Version of SSV format, 1.0 or 2.0-alpha for this release.
                     </xs:documentation>
                 </xs:annotation>
                 <xs:simpleType>
                     <xs:restriction base="xs:normalizedString">
+                        <xs:pattern value="1[.]0"/>
                         <xs:pattern value="2[.][0-9]+(-.+)"/>
                     </xs:restriction>
                 </xs:simpleType>

--- a/schema/SystemStructureSignalDictionary.xsd
+++ b/schema/SystemStructureSignalDictionary.xsd
@@ -56,11 +56,12 @@
             <xs:attribute name="version" use="required">
                 <xs:annotation>
                     <xs:documentation xml:lang="en">
-                        Version of SSB format, 2.0-alpha for this release.
+                        Version of SSB format, 1.0 or 2.0-alpha for this release.
                     </xs:documentation>
                 </xs:annotation>
                 <xs:simpleType>
                     <xs:restriction base="xs:normalizedString">
+                        <xs:pattern value="1[.]0"/>
                         <xs:pattern value="2[.][0-9]+(-.+)"/>
                     </xs:restriction>
                 </xs:simpleType>


### PR DESCRIPTION
Closes #41. This updates both the text and schemas to allow both 1.0 and 2.0. For now retains the restriction to development versions of 2.0, to be changed later on.