### PR TITLE
Editorial fixes for the SSP 2.0 documentation

### DIFF
--- a/docs/1___overview.adoc
+++ b/docs/1___overview.adoc
@@ -4,7 +4,7 @@ SSP is a tool-independent format for the description, packaging and exchange of 
 The standard is comprised of a set of XML-based formats to describe a network of component models with their signal flow and parametrization, as well as a ZIP-based packaging format for efficient distribution of entire systems, including any referenced models and other resources.
 This description is tool neutral and is intended to be used primarly as an exchange format of simulation system descriptions between different tools.
 
-SSP can be seen as an extension to the FMI (Functional Mockup Interface) standard [FMI20].
+SSP can be seen as an extension to the FMI (Functional Mockup Interface) standard [FMI20] [FMI30].
 FMI describes a tool independent standard to exchange single simulation models.
 Using SSP, complete systems consisting of multiple interconnected simulation models can be defined with the desired signal flow and also with the wanted parameterization of each single model as well as the parameters for the complete system.
 This system topology can include hierarchies of sub-systems for proper structuring of the overall system.
@@ -52,7 +52,6 @@ From a simulation perspective, each component has to be described with its input
 This can be done using SSP by defining the wrapper of this component with an empty Component element comprising the connectors for the inputs and outputs and the component's parameters.
 
 The interaction of the components is defined by the connections.
-Connections in SSP are always causal.
 Connections can be made directly between components or via signal dictionaries.
 A signal dictionary is a collection of signals similar to a bus concept (e.g. like a CAN bus).
 During the design phase of a system, a signal dictionary can be a good way to predefine the available signal connections.
@@ -123,10 +122,11 @@ The following companies and persons were involved in the creation of the standar
 
 * Christian Bertsch, Bosch
 * Dag Brück, Dassault Systèmes
-* Markus Deppe, dSpace
+* Markus Deppe, dSPACE
 * Hans-Martin Heinkel, Bosch
 * Maria Henningsson, Modelon
 * Jan-Niklas Jäschke, TLK-Thermo
+* Ulrich Kiffmeier, dSPACE
 * Jochen Köhler, ZF Friedrichshafen
 * Jürgen Krasser, AVL
 * Peter Lobner, eXXcellent solutions

--- a/docs/1___overview.adoc
+++ b/docs/1___overview.adoc
@@ -4,7 +4,7 @@ SSP is a tool-independent format for the description, packaging and exchange of 
 The standard is comprised of a set of XML-based formats to describe a network of component models with their signal flow and parametrization, as well as a ZIP-based packaging format for efficient distribution of entire systems, including any referenced models and other resources.
 This description is tool neutral and is intended to be used primarly as an exchange format of simulation system descriptions between different tools.
 
-SSP can be seen as an extension to the FMI (Functional Mockup Interface) standard [FMI20] [FMI30].
+SSP can be seen as an extension to the FMI (Functional Mockup Interface) standard [FMI20].
 FMI describes a tool independent standard to exchange single simulation models.
 Using SSP, complete systems consisting of multiple interconnected simulation models can be defined with the desired signal flow and also with the wanted parameterization of each single model as well as the parameters for the complete system.
 This system topology can include hierarchies of sub-systems for proper structuring of the overall system.
@@ -52,6 +52,7 @@ From a simulation perspective, each component has to be described with its input
 This can be done using SSP by defining the wrapper of this component with an empty Component element comprising the connectors for the inputs and outputs and the component's parameters.
 
 The interaction of the components is defined by the connections.
+Connections in SSP are always causal.
 Connections can be made directly between components or via signal dictionaries.
 A signal dictionary is a collection of signals similar to a bus concept (e.g. like a CAN bus).
 During the design phase of a system, a signal dictionary can be a good way to predefine the available signal connections.

--- a/docs/4___common_content.adoc
+++ b/docs/4___common_content.adoc
@@ -136,7 +136,7 @@ The following XML child elements are specified for the Unit element:
 ===== BaseUnit
 
 This element defines the base unit of the given unit in SI units.
-This is completely aligned with the specification of base units in section 2.2.2 of the FMI 2.0 standard [FMI20].
+This is completely aligned with the specification of base units in section 2.4.3 of the FMI 3.0 standard [FMI30].
 
 image:images/image10.png[image,width=263,height=771]
 
@@ -462,17 +462,18 @@ This attribute references another connector by name, that gives the size of this
 |===
 
 [#ssc_metadata]
-==== MetaData Sequence
+==== MetaData and Signatures
 
 image:images/SystemStructureCommon_GMetaData.png[image,width=597,height=196]
 
-The MetaData element allows the specification of additional meta data for a given model element.
-Multiple (or no) MetaData elements may be present in a given model element.
+The group GMetaData allows the specification of additional meta data and signatures for a given model element.
+Multiple (or no) MetaData and Signature elements may be present in a given model element.
 
 [width="100%",cols="33%,67%",options="header",]
 |===
 |Element  |Description
 |MetaData |One or more instances of this element *CAN* be present to specify meta data related to the containing model element.
+|Signature |One or more instances of this element *CAN* be present to specify signatures related to the containing model element.
 See below for details.
 |===
 
@@ -507,15 +508,18 @@ The kind can be `general` or `quality`, indicating general meta data or quality 
 This mandatory attribute specifies the MIME type of the meta data, which does not have a default value.
 If no specific MIME type can be indicated, then the type `application/octet-stream` is to be used.
 |source a|
-Optional attribute indicating the source of the meta data as a URI (cf. RFC 3986).
-For purposes of the resolution of relative URIs the base URI is the URI of the SSD, if the sourceBase attribute is not specified or is specified as `SSD`, and the URI of the containing model element (e.g. component) if the base attribute is specified as `component`.
+This attribute indicates the source of the resource meta data as a URI (cf. RFC 3986). 
+For purposes of the resolution of relative URIs the base URI is the URI of the SSD,
+if the sourceBase attribute is not specified or is specified as SSD,
+and the URI of the referenced resource if the sourceBase attribute is specified as resource.
 
 This allows the specification of meta data sources that reside inside the component (for example an FMU) through relative URIs.
 
 If the source attribute is missing, the meta data *MUST* be provided inline as contents of a Content element, which *MUST NOT* be present otherwise.
 |sourceBase a|
 Defines the base the source URI is resolved against:
-If the attribute is missing or is specified as `SSD`, the source is resolved against the URI of the SSD, if the attribute is specified as `component` the URI is resolved against the (resolved) URI of the model element (e.g. component) source.
+If the attribute is missing or is specified as SSD, the source is resolved against the URI of the SSD,
+if the attribute is specified as resource the URI is resolved against the (resolved) URI of the resource source.
 |===
 
 ===== Content

--- a/docs/4___common_content.adoc
+++ b/docs/4___common_content.adoc
@@ -136,7 +136,7 @@ The following XML child elements are specified for the Unit element:
 ===== BaseUnit
 
 This element defines the base unit of the given unit in SI units.
-This is completely aligned with the specification of base units in section 2.4.3 of the FMI 3.0 standard [FMI30].
+This is completely aligned with the specification of base units in section 2.2.2 of the FMI 2.0 standard [FMI20].
 
 image:images/image10.png[image,width=263,height=771]
 

--- a/docs/5___ssd.adoc
+++ b/docs/5___ssd.adoc
@@ -17,7 +17,7 @@ The root element of an SSD file *MUST* be a SystemStructureDescription element, 
 |Attribute |Description
 |version |This required attribute specifies the version of this specification that the system description conforms to.
 Only major and minor version number are included, the patch version number *MUST NOT* be included in this attribute.
-For the current release this *MUST* be 2.0 or 1.0.
+For the current release this *MUST* be 1.0.
 |name |This required attribute provides a name, which can be used for purposes of presenting the system structure to the user, for example when selecting individual variant SSDs from an SSP.
 |===
 

--- a/docs/5___ssd.adoc
+++ b/docs/5___ssd.adoc
@@ -17,7 +17,7 @@ The root element of an SSD file *MUST* be a SystemStructureDescription element, 
 |Attribute |Description
 |version |This required attribute specifies the version of this specification that the system description conforms to.
 Only major and minor version number are included, the patch version number *MUST NOT* be included in this attribute.
-For the current release this *MUST* be 1.0.
+For the current release this *MUST* be 2.0 or 1.0.
 |name |This required attribute provides a name, which can be used for purposes of presenting the system structure to the user, for example when selecting individual variant SSDs from an SSP.
 |===
 
@@ -31,8 +31,6 @@ The following XML child elements are specified for the SystemStructureDescriptio
 |Units |This optional element *MUST* contain definitions for all units referenced in the system description file. See <<Units>> for its definition.
 |DefaultExperiment |This optional element *MAY* contain information of a default simulation setup that is supplied with the system definition for informational purposes, see description below.
 |===
-
-The root system of the model is specified through the required System element, see <<System>>.
 
 Any enumerations and units referenced in the system description file *MUST* be provided through the optional Enumerations and Units elements, as described in <<Enumerations>> and <<Units>> respectively.
 
@@ -95,8 +93,8 @@ For components the set of connectors *MUST* match variables/ports of the underly
 For FMI 3.0 FMUs, the connector name has to match either the name of the corresponding variable element, or one of its <Alias> elements.
 
 Names of variable elements of an FMU might follow the “Variable Naming Conventions” specification as defined by the FMI standard.
-Hence, several ScalarVariables might be grouped as a structure or an array.
-However, the name of a connector *MUST* match the name of a single <ScalarVariable>.
+Hence, several variables might be grouped as a structure or an array.
+However, the name of a connector *MUST* match the name of a single variable.
 
 Note that there is no requirement that connectors have to be present for all variables/ports of an underlying component implementation.
 At least those connectors *MUST* be present which are referenced in connections inside the SSD.
@@ -156,12 +154,6 @@ Boolean / String / Enumeration / Binary / Clock |Exactly one of these elements *
 |Clock |One or more of these optional elements associate the connector to a clock of the given name, which must be defined on the element that contains this connector.
 |ConnectorGeometry |This optional element defines the geometry information of the connector. See below for details.
 |===
-
-The type of the Connector is identified by the presence of one of the XML child elements Real, Float64, Float32, Integer, Int8, UInt8, Int16, UInt16, Int32, UInt32, Int64, UInt64, Boolean, String, Enumeration, Binary, or Clock.
-
-The dimensionality of the Connector is given by the presence of one or more Dimension elements.
-
-The association of a connector to a clock is given by the presence of one or more Clock elements.
 
 When Modelica models are represented in SSP, built-in input and output connectors shall be mapped as follows:
 
@@ -410,7 +402,7 @@ For structural parameters it is assumed that the parameterization is applied in 
 This means that variables eligible for parameterization are those with:
 
 * either causality = "input" or a start value for FMI 1.0
-* variability != "constant" and initial = "exact" or "approx" for FMI 2.0
+* variability != "constant" and initial = "exact" or "approx" for FMI 2.0 or FMI 3.0
 
 All kinds of system connectors can be parameterized.
 In case the system level connectors are connected to FMU components, the parameterization *MUST* be compatible with the variable in the connected FMU.

--- a/docs/A___literature.adoc
+++ b/docs/A___literature.adoc
@@ -12,11 +12,8 @@ https://semver.org/spec/v2.0.0.html
 [XML10] World Wide Web Consortium: *Extensible Markup Language (XML) 1.0 (Fifth Edition).* W3C Recommendation. 2008. +
 http://www.w3.org/TR/2008/REC-xml-20081126/
 
-[FMI20] Modelica Association: *Functional Mock-up Interface for Model Exchange and Co-Simulation, Version 2.0.4.* 2022. +
-https://github.com/modelica/fmi-standard/releases/download/v2.0.4/FMI-Specification-2.0.4.pdf
-
-[FMI30] Modelica Association: *Functional Mock-up Interface Specification, Version 3.0.1.* 2023. +
-https://fmi-standard.org/docs/3.0.1/
+[FMI20] Modelica Association: *Functional Mock-up Interface for Model Exchange and Co-Simulation, Version 2.0.3.* 2021. +
+https://github.com/modelica/fmi-standard/releases/download/v2.0.3/FMI-Specification-2.0.3.pdf
 
 [OSMP120] ASAM e.V.: *OSI Sensor Model Packaging Version 1.2.0.* 2021. +
 https://github.com/OpenSimulationInterface/osi-sensor-model-packaging/releases/tag/v1.2.0

--- a/docs/A___literature.adoc
+++ b/docs/A___literature.adoc
@@ -12,8 +12,11 @@ https://semver.org/spec/v2.0.0.html
 [XML10] World Wide Web Consortium: *Extensible Markup Language (XML) 1.0 (Fifth Edition).* W3C Recommendation. 2008. +
 http://www.w3.org/TR/2008/REC-xml-20081126/
 
-[FMI20] Modelica Association: *Functional Mock-up Interface for Model Exchange and Co-Simulation, Version 2.0.3.* 2021. +
-https://github.com/modelica/fmi-standard/releases/download/v2.0.3/FMI-Specification-2.0.3.pdf
+[FMI20] Modelica Association: *Functional Mock-up Interface for Model Exchange and Co-Simulation, Version 2.0.4.* 2022. +
+https://github.com/modelica/fmi-standard/releases/download/v2.0.4/FMI-Specification-2.0.4.pdf
+
+[FMI30] Modelica Association: *Functional Mock-up Interface Specification, Version 3.0.1.* 2023. +
+https://fmi-standard.org/docs/3.0.1/
 
 [OSMP120] ASAM e.V.: *OSI Sensor Model Packaging Version 1.2.0.* 2021. +
 https://github.com/OpenSimulationInterface/osi-sensor-model-packaging/releases/tag/v1.2.0

--- a/schema/SystemStructureCommon.xsd
+++ b/schema/SystemStructureCommon.xsd
@@ -1,822 +1,619 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
-    xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
-    targetNamespace="http://ssp-standard.org/SSP1/SystemStructureCommon">
-    <xs:annotation>
-        <xs:documentation xml:lang="en">
-            This is the normative XML Schema 1.0 schema for the MAP SSP
-            SystemStructure 2.0 common content across formats.
-            
-            Version: 2.0-alpha
-
-            Copyright 2016 -- 2019 Modelica Association Project "SSP"
-
-            Redistribution and use in source and binary forms, with or
-            without modification, are permitted provided that the
-            following conditions are met:
-
-            1. Redistributions of source code must retain the above
-               copyright notice, this list of conditions and the
-               following disclaimer.
-
-            2. Redistributions in binary form must reproduce the above
-               copyright notice, this list of conditions and the
-               following disclaimer in the documentation and/or other
-               materials provided with the distribution.
-
-            THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
-            CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-            INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-            MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-            DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
-            CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-            INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-            (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
-            GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
-            BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-            LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-            (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
-            OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-            POSSIBILITY OF SUCH DAMAGE.
-        </xs:documentation>
-    </xs:annotation>
-    
-    <xs:attributeGroup name="ABaseElement">
-        <xs:annotation>
-            <xs:documentation xml:lang="en">
-                This attribute group specifies the attributes common to all model elements.
-            </xs:documentation>
-        </xs:annotation>
-        <xs:attribute name="id" type="xs:ID" use="optional">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
-                    This attribute gives the model element a file-wide unique id which can
-                    be referenced from other elements or via URI fragment identifier.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="description" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
-                    This attribute gives a human readable longer description of the
-                    model element, which can be shown to the user where appropriate. 
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:attributeGroup>
-    
-    <xs:attributeGroup name="ATopLevelMetaData">
-        <xs:annotation>
-            <xs:documentation xml:lang="en">
-                This attribute group specifies the optional meta-data attributes common to 
-                all top-level container elements of all defined file formats.
-            </xs:documentation>
-        </xs:annotation>
-        <xs:attribute name="author" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
-                    This attribute gives the name of the author of this file's content. 
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="fileversion" type="xs:normalizedString" use="optional">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
-                    This attribute gives a version number for this file's content. 
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="copyright" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
-                    This attribute gives copyright information for this file's content. 
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="license" type="xs:string" use="optional">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
-                    This attribute gives license information for this file's content. 
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="generationTool" type="xs:normalizedString">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
-                    This attribute gives the name of the tool that generated this file. 
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="generationDateAndTime" type="xs:dateTime">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
-                    This attribute gives the date and time this file was generated. 
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:attributeGroup>
-    
-    <xs:simpleType name="TGenericInteger">
-        <xs:restriction base="xs:integer">
-            <xs:maxInclusive value="18446744073709551615"/>
-            <xs:minInclusive value="-9223372036854775808"/>
-        </xs:restriction>
-    </xs:simpleType>
-    
-    <xs:complexType name="TEnumerations">
-        <xs:sequence>
-            <xs:element name="Enumeration" minOccurs="1" maxOccurs="unbounded" type="ssc:TEnumeration"/>
-        </xs:sequence>
-    </xs:complexType>
-    
-    <xs:complexType name="TEnumeration">
-        <xs:sequence>
-            <xs:element name="Item" minOccurs="1" maxOccurs="unbounded">
-                <xs:complexType>
-                    <xs:attribute name="name" type="xs:string" use="required">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">Name of the Enumeration Item</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="value" type="xs:int" use="required">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">The Value of the Enumeration Item</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
-        </xs:sequence>
-        <xs:attributeGroup ref="ssc:ABaseElement"/>
-        <xs:attribute name="name" type="xs:string" use="required">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
-                    This attribute specifies the name of the enumeration in the system description,
-                    which must be unique within in the system description.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:complexType>
-    
-    <xs:complexType name="TUnits">
-        <xs:sequence>
-            <xs:element name="Unit" minOccurs="1" maxOccurs="unbounded" type="ssc:TUnit"/>
-        </xs:sequence>
-    </xs:complexType>
-    
-    <xs:complexType name="TUnit">
-        <xs:sequence>
-            <xs:element name="BaseUnit">
-                <xs:complexType>
-                    <xs:attribute name="kg" type="xs:int" default="0">
-                        <xs:annotation>
-                            <xs:documentation>Exponent of SI base unit "kg"</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="m" type="xs:int" default="0">
-                        <xs:annotation>
-                            <xs:documentation>Exponent of SI base unit "m"</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="s" type="xs:int" default="0">
-                        <xs:annotation>
-                            <xs:documentation>Exponent of SI base unit "s"</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="A" type="xs:int" default="0">
-                        <xs:annotation>
-                            <xs:documentation>Exponent of SI base unit "A"</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="K" type="xs:int" default="0">
-                        <xs:annotation>
-                            <xs:documentation>Exponent of SI base unit "K"</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="mol" type="xs:int" default="0">
-                        <xs:annotation>
-                            <xs:documentation>Exponent of SI base unit "mol"</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="cd" type="xs:int" default="0">
-                        <xs:annotation>
-                            <xs:documentation>Exponent of SI base unit "cd"</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="rad" type="xs:int" default="0">
-                        <xs:annotation>
-                            <xs:documentation>Exponent of SI derived unit "rad"</xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="factor" type="xs:double" default="1"/>
-                    <xs:attribute name="offset" type="xs:double" default="0"/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
-        </xs:sequence>
-        <xs:attributeGroup ref="ssc:ABaseElement"/>
-        <xs:attribute name="name" type="xs:string" use="required">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
-                    This attribute specifies the name of the unit in the system description,
-                    which must be unique within in the system description.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:complexType>
-    
-    <xs:complexType name="TAnnotations">
-        <xs:sequence maxOccurs="unbounded">
-            <xs:element name="Annotation">
-                <xs:complexType mixed="true">
-                    <xs:sequence>
-                        <xs:any namespace="##any" processContents="lax" minOccurs="0"/>
-                    </xs:sequence>
-                    <xs:attribute name="type" type="xs:normalizedString" use="required">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
-                                The unique name of the type of the annotation.
-                                
-                                In order to ensure uniqueness all types should be identified
-                                with reverse domain name notation (cf. Java package names
-                                or Apple UTIs) of a domain that is controlled by the entity
-                                defining the semantics and content of the annotation.
-                                
-                                For vendor-specific annotations this would e.g. be a domain
-                                controlled by the tool vendor.
-                                
-                                For MAP-SSP defined annotations, this will be a domain under
-                                the org.modelica prefix.
-                            </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:complexType>
-            </xs:element>
-        </xs:sequence>
-    </xs:complexType>
-    
-    <xs:group name="GMetaData">
-        <xs:sequence>
-            <xs:element name="MetaData" minOccurs="0" maxOccurs="unbounded">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
-                        This element can specify additional meta data for the given resource. Multiple
-                        (or no) MetaData elements may be present.
-                    </xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element name="Content" type="ssc:ContentType" minOccurs="0" maxOccurs="1">
-                            <xs:annotation>
-                                <xs:documentation xml:lang="en">
-                                    This optional element can contain inlined content of the resource meta data. If it
-                                    is present, then the attribute source of the MetaData element must not be present.
-                                </xs:documentation>
-                            </xs:annotation>
-                        </xs:element>
-                        <xs:element name="Signature" type="ssc:SignatureType" minOccurs="0" maxOccurs="unbounded">
-                            <xs:annotation>
-                                <xs:documentation xml:lang="en">
-                                    This element can contain digital signature information on the meta data referenced
-                                    by the enclosing MetaData element. It is left unspecified what types of signatures
-                                    are used and/or available for now.  Multiple or no signature elements may be present.
-                                </xs:documentation>
-                            </xs:annotation>
-                        </xs:element>
-                    </xs:sequence>
-                    <xs:attribute name="kind" use="required">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
-                                This attribute indicates the kind of resource meta data that is referenced, i.e.
-                                what role it plays in relation to the resource being described.
-                            </xs:documentation>
-                        </xs:annotation>
-                        <xs:simpleType>
-                            <xs:restriction base="xs:string">
-                                <xs:enumeration value="general"/>
-                                <xs:enumeration value="quality"/>
-                            </xs:restriction>
-                        </xs:simpleType>
-                    </xs:attribute>
-                    <xs:attribute name="type" type="xs:string" use="required">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
-                                This mandatory attribute specifies the MIME type of the resource meta data, which
-                                does not have a default value.  If no specific MIME type can be indicated, then
-                                the type application/octet-stream is to be used.
-                            </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="source" type="xs:anyURI" use="optional">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
-                                This attribute indicates the source of the resource meta data as a
-                                URI (cf. RFC 3986).  For purposes of the resolution of relative URIs
-                                the base URI is the URI of the STC, if the sourceBase attribute is
-                                not specified or is specified as STC, and the URI of the referenced
-                                resource if the sourceBase attribute is specified as resource.
-                                
-                                This allows the specification of meta data sources that reside
-                                inside the resource (e.g. an FMU) through relative URIs.
-                                
-                                For meta data that are located alongside the STC, relative URIs
-                                without scheme and authority can and should be used to specify the
-                                meta data sources.  For meta data that are packaged inside an SSP
-                                that contains this STC, this is mandatory (in this way, the STC
-                                URIs remain valid after unpacking the SSP into the filesystem).
-                                
-                                If the source attribute is missing, the meta data is provided
-                                inline as contents of the Content element, which must not be
-                                present otherwise.
-                            </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="sourceBase" use="optional" default="SSD">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
-                                Defines the base the source URI is resolved against:  If the attribute
-                                is missing or is specified as SSD, the source is resolved against the
-                                URI of the SSD, if the attribute is specified as resource the URI is
-                                resolved against the (resolved) URI of the resource source.
-                            </xs:documentation>
-                        </xs:annotation>
-                        <xs:simpleType>
-                            <xs:restriction base="xs:string">
-                                <xs:enumeration value="SSD"/>
-                                <xs:enumeration value="resource"/>
-                            </xs:restriction>
-                        </xs:simpleType>
-                    </xs:attribute>
-                    <xs:attributeGroup ref="ssc:ABaseElement"/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="Signature" type="ssc:SignatureType" minOccurs="0" maxOccurs="unbounded">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
-                        This element can contain digital signature information on the data referenced
-                        by the enclosing element. It is left unspecified what types of signatures
-                        are used and/or available for now.  Multiple or no signature elements may be present.
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-        </xs:sequence>
-    </xs:group>
-
-    <xs:complexType name="SignatureType">
-        <xs:sequence>
-            <xs:element name="Content" type="ssc:ContentType" minOccurs="0" maxOccurs="1"/>
-        </xs:sequence>
-        <xs:attribute name="role" use="required">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
-                    This mandatory attribute specifies the role this signature has in the overall
-                    process. It indicates whether the digital signature is intended to just convey
-                    the authenticity of the information, or whether a claim for suitability of
-                    the information for certain purposes is made.  In the later case, the digital
-                    signature format should include detailed information about what suitability
-                    claims are being made.
-                </xs:documentation>
-            </xs:annotation>
-            <xs:simpleType>
-                <xs:restriction base="xs:string">
-                    <xs:enumeration value="authenticity"/>
-                    <xs:enumeration value="suitability"/>
-                </xs:restriction>
-            </xs:simpleType>
-        </xs:attribute>
-        <xs:attribute name="type" type="xs:string" use="required">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
-                    This mandatory attribute specifies the MIME type of the resource signature, which
-                    does not have a default value.  If no specific MIME type can be indicated, then
-                    the type application/octet-stream is to be used.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="source" type="xs:anyURI" use="optional">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
-                    This attribute indicates the source of the digital signature as a
-                    URI (cf. RFC 3986).  For purposes of the resolution of relative URIs
-                    the base URI is the URI of the SSD, if the sourceBase attribute is
-                    not specified or is specified as SSD, the URI of the  containing model
-                    element (e.g. component) if the sourceBase attribute is specified as
-                    component, or the URI of the meta data source if the sourceBase
-                    attribute is specified as metaData.
-                    
-                    This allows the specification of signature sources that reside
-                    inside the component (for example an FMU), or the meta data
-                    through relative URIs.
-                    
-                    If the source attribute is missing, the signature is provided
-                    inline as contents of the Content element, which must not be
-                    present otherwise.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="sourceBase" use="optional" default="SSD">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
-                    Defines the base the source URI is resolved against: If the attribute
-                    is missing or is specified as SSD, the source is resolved against the
-                    URI of the SSD, if the attribute is specified as component the URI is
-                    resolved against the (resolved) URI of the model element (e.g.
-                    component) source, or if the attribute is specified as metaData the
-                    URI is resolved against the (resolved) URI of the meta data source.
-                    The value metaData is only valid if the Signature element is contained
-                    within a MetaData element.
-                </xs:documentation>
-            </xs:annotation>
-            <xs:simpleType>
-                <xs:restriction base="xs:string">
-                    <xs:enumeration value="SSD"/>
-                    <xs:enumeration value="component"/>
-                    <xs:enumeration value="metaData"/>
-                </xs:restriction>
-            </xs:simpleType>
-        </xs:attribute>
-        <xs:attributeGroup ref="ssc:ABaseElement"/>
-    </xs:complexType>
-
-    <xs:complexType name="ContentType" mixed="true">
-        <xs:annotation>
-            <xs:documentation xml:lang="en">
-                This optional element can contain inlined content of an entity. If it is present,
-                then the attribute source of the enclosing element must not be present.
-            </xs:documentation>
-        </xs:annotation>
-        <xs:choice>
-            <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:choice>
-        <xs:attributeGroup ref="ssc:ABaseElement"/>
-    </xs:complexType>
-
-    <xs:group name="GTypeChoice">
-        <xs:choice>
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
-                    This element gives the type of a connector or signal dictionary entry
-                    (called entity below).
-                </xs:documentation>
-            </xs:annotation>
-            <xs:element name="Real">
-                <xs:complexType>
-                    <xs:attribute name="unit" type="xs:string" use="optional">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
-                                This attribute gives the unit of the entity and must
-                                reference one of the unit definitions provided in the Units
-                                element of the containing file.
-                                
-                                If a unit is not supplied, the unit is determined through
-                                default mechanisms: For FMU components, the unit of the
-                                underlying variable would be used, for systems the units
-                                of connected underlying connectors could be used if unambiguous.
-                                If a unit cannot be deduced unambinguously, the user should
-                                be informed of this error.
-                            </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="Float64">
-                <xs:complexType>
-                    <xs:attribute name="unit" type="xs:string" use="optional">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
-                                This attribute gives the unit of the entity and must
-                                reference one of the unit definitions provided in the Units
-                                element of the containing file.
-                                
-                                If a unit is not supplied, the unit is determined through
-                                default mechanisms: For FMU components, the unit of the
-                                underlying variable would be used, for systems the units
-                                of connected underlying connectors could be used if unambiguous.
-                                If a unit cannot be deduced unambinguously, the user should
-                                be informed of this error.
-                            </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="Float32">
-                <xs:complexType>
-                    <xs:attribute name="unit" type="xs:string" use="optional">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
-                                This attribute gives the unit of the entity and must
-                                reference one of the unit definitions provided in the Units
-                                element of the containing file.
-                                
-                                If a unit is not supplied, the unit is determined through
-                                default mechanisms: For FMU components, the unit of the
-                                underlying variable would be used, for systems the units
-                                of connected underlying connectors could be used if unambiguous.
-                                If a unit cannot be deduced unambinguously, the user should
-                                be informed of this error.
-                            </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="Integer">
-                <xs:complexType>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="Int8">
-                <xs:complexType>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="UInt8">
-                <xs:complexType>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="Int16">
-                <xs:complexType>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="UInt16">
-                <xs:complexType>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="Int32">
-                <xs:complexType>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="UInt32">
-                <xs:complexType>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="Int64">
-                <xs:complexType>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="UInt64">
-                <xs:complexType>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="Boolean">
-                <xs:complexType>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="String">
-                <xs:complexType>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="Enumeration">
-                <xs:complexType>
-                    <xs:attribute name="name" type="xs:string" use="required">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
-                                This attribute specifies the name of the enumeration
-                                which references into the set of defined enumerations
-                                of the system structure description, as contained in
-                                the Enumerations element of the root element.
-                            </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="Binary">
-                <xs:complexType>
-                    <xs:attribute name="mime-type" type="xs:string" default="application/octet-stream">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
-                                This optional attribute specifies the MIME type of the
-                                underlying binary data, which defaults to the non-specific
-                                application/octet-stream type.  This information can be
-                                used by the implementation to detect mismatches between
-                                connected binary connectors, or provide automatic means of
-                                conversion between different formats.  It should be noted
-                                that the implementation is not required to provide this
-                                service, i.e. it remains the responsibility of the operator 
-                                to ensure only compatible binary connectors are connected.
-                            </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="Clock">
-                <xs:complexType>
-                  <xs:attribute name="intervalVariability" use="optional">
-                    <xs:simpleType>
-                      <xs:restriction base="xs:normalizedString">
-                        <xs:enumeration value="constant"/>
-                        <xs:enumeration value="fixed"/>
-                        <xs:enumeration value="tunable"/>
-                        <xs:enumeration value="changing"/>
-                        <xs:enumeration value="countdown"/>
-                        <xs:enumeration value="triggered"/>
-                      </xs:restriction>
-                    </xs:simpleType>
-                  </xs:attribute>
-                  <xs:attribute name="intervalDecimal" type="xs:double" use="optional"/>
-                  <xs:attribute name="shiftDecimal" type="xs:double" default="0"/>
-                  <xs:attribute name="supportsFraction" type="xs:boolean" default="false"/>
-                  <xs:attribute name="resolution" type="xs:unsignedLong" use="optional"/>
-                  <xs:attribute name="intervalCounter" type="xs:unsignedLong" use="optional"/>
-                  <xs:attribute name="shiftCounter" type="xs:unsignedLong" default="0"/>
-                  <xs:attribute name="priority" type="xs:unsignedInt" use="optional"/>
-                </xs:complexType>
-            </xs:element>
-        </xs:choice>
-    </xs:group>
-    
-    <xs:group name="GTransformationChoice">
-        <xs:annotation>
-            <xs:documentation xml:lang="en">
-                This element specifies the transformation to be applied to a value prior to its
-                use in a connection or parameter mapping.
-            </xs:documentation>
-        </xs:annotation>
-        <xs:choice>
-            <xs:element name="LinearTransformation">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
-                        This element provides for a linear transformation to be performed on the
-                        parameter values and is valid for parameters of a continuous type.
-                    </xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:attribute name="factor" type="xs:double" use="optional" default="1.0">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
-                                This attribute specifies an optional factor value to use in a linear
-                                transformation of the source parameter value to the target parameter
-                                value, i.e. in the calculation target = factor * source + offset.
-                                
-                                Note that conversions based on different units are performed, unless
-                                prevented by suppressUnitConversion, prior to the application of the
-                                linear transformation, i.e. the value of source is already converted
-                                to the target unit in the formula above.
-                            </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="offset" type="xs:double" use="optional" default="0.0">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
-                                This attribute specifies an optional offset value to use in a linear
-                                transformation of the source parameter value to the target parameter
-                                value, i.e. in the calculation target = factor * source + offset.
-                                
-                                Note that conversions based on different units are performed, unless
-                                prevented by suppressUnitConversion, prior to the application of the
-                                linear transformation, i.e. the value of source is already converted
-                                to the target unit in the formula above.
-                            </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="BooleanMappingTransformation">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
-                        This element provides for a transformation of boolean parameter values
-                        based on a mapping table and is valid for parameters of boolean type.
-                        Each mapping table entry is provided by a MapEntry element.
-                    </xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element name="MapEntry" minOccurs="1" maxOccurs="unbounded">
-                            <xs:complexType>
-                                <xs:attribute name="source" type="xs:boolean" use="required">
-                                    <xs:annotation>
-                                        <xs:documentation xml:lang="en">
-                                            This attribute gives the value of the parameter in the
-                                            parameter source that this entry applies to.
-                                        </xs:documentation>
-                                    </xs:annotation>
-                                </xs:attribute>
-                                <xs:attribute name="target" type="xs:boolean" use="required">
-                                    <xs:annotation>
-                                        <xs:documentation xml:lang="en">
-                                            This attribute gives the value of the parameter to use
-                                            when applying it to the system or component that is to be
-                                            parametrized.
-                                        </xs:documentation>
-                                    </xs:annotation>
-                                </xs:attribute>
-                            </xs:complexType>
-                        </xs:element>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="IntegerMappingTransformation">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
-                        This element provides for a transformation of integer parameter values
-                        based on a mapping table and is valid for parameters of all integer and 
-                        enumeration types.  Each mapping table entry is provided by a MapEntry
-                        element.
-                    </xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element name="MapEntry" minOccurs="1" maxOccurs="unbounded">
-                            <xs:complexType>
-                                <xs:attribute name="source" type="ssc:TGenericInteger" use="required">
-                                    <xs:annotation>
-                                        <xs:documentation xml:lang="en">
-                                            This attribute gives the value of the parameter in the
-                                            parameter source that this entry applies to.
-                                        </xs:documentation>
-                                    </xs:annotation>
-                                </xs:attribute>
-                                <xs:attribute name="target" type="ssc:TGenericInteger" use="required">
-                                    <xs:annotation>
-                                        <xs:documentation xml:lang="en">
-                                            This attribute gives the value of the parameter to use
-                                            when applying it to the system or component that is to be
-                                            parametrized.
-                                        </xs:documentation>
-                                    </xs:annotation>
-                                </xs:attribute>
-                            </xs:complexType>
-                        </xs:element>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="EnumerationMappingTransformation">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
-                        This element provides for a transformation of enumeration parameter values
-                        based on a mapping table of their enumeration item names and is valid for
-                        parameters of enumeration type.  Each mapping table entry is provided by a
-                        MapEntry element.
-                    </xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element name="MapEntry" minOccurs="1" maxOccurs="unbounded">
-                            <xs:complexType>
-                                <xs:attribute name="source" type="xs:string" use="required">
-                                    <xs:annotation>
-                                        <xs:documentation xml:lang="en">
-                                            This attribute gives the value of the parameter in the
-                                            parameter source that this entry applies to.
-                                        </xs:documentation>
-                                    </xs:annotation>
-                                </xs:attribute>
-                                <xs:attribute name="target" type="xs:string" use="required">
-                                    <xs:annotation>
-                                        <xs:documentation xml:lang="en">
-                                            This attribute gives the value of the parameter to use
-                                            when applying it to the system or component that is to be
-                                            parametrized.
-                                        </xs:documentation>
-                                    </xs:annotation>
-                                </xs:attribute>
-                            </xs:complexType>
-                        </xs:element>
-                    </xs:sequence>
-                </xs:complexType>
-            </xs:element>
-        </xs:choice>
-    </xs:group>
-    
-    <xs:group name="GDimensions">
-        <xs:sequence>
-            <xs:element name="Dimension" minOccurs="0" maxOccurs="unbounded">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
-                        This optional element specifies one dimension of an array connector.
-                        If no dimension elements are present in a connector, it is a scalar
-                        connector. The number of dimension elements in a connector provides
-                        the dimensionality of the array.
-                        
-                        Either the size or the sizeConnector attributes CAN be present
-                        on the element, indicating a fixed size, or a size that depends on
-                        the structural parameter or constant referenced by the sizeConnector
-                        attribute.
-                        
-                        If none of the attributes are present, then the size of the dimension
-                        is unspecified at the SSD level. If both attributes are present this
-                        is considered an error.
-                    </xs:documentation>
-                </xs:annotation>
-                <xs:complexType>
-                    <xs:attribute name="size" type="xs:unsignedLong" use="optional">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
-                                This attribute gives the size of this dimension of the
-                                connector as a fixed, unchangeable number.
-                            </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                    <xs:attribute name="sizeConnector" type="xs:string" use="optional">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
-                                This attribute references another connector by name, that
-                                gives the size of this dimension of the connector, e.g. a
-                                structural parameter or a constant of the underlying
-                                component that gives the dimension size.
-                            </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:complexType>
-            </xs:element>
-        </xs:sequence>
-    </xs:group>
-    
+<xs:schema elementFormDefault="qualified" targetNamespace="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:annotation>
+		<xs:documentation xml:lang="en">
+			This is the normative XML Schema 1.0 schema for the MAP SSP SystemStructure 2.0 common content across formats. Version: 2.0-alpha Copyright 2016 -- 2019 Modelica Association Project "SSP" Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+		</xs:documentation>
+	</xs:annotation>
+	<xs:attributeGroup name="ABaseElement">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">
+				This attribute group specifies the attributes common to all model elements.
+			</xs:documentation>
+		</xs:annotation>
+		<xs:attribute name="description" type="xs:string" use="optional">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
+					This attribute gives a human readable longer description of the model element, which can be shown to the user where appropriate.
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="id" type="xs:ID" use="optional">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
+					This attribute gives the model element a file-wide unique id which can be referenced from other elements or via URI fragment identifier.
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:attributeGroup>
+	<xs:attributeGroup name="ATopLevelMetaData">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">
+				This attribute group specifies the optional meta-data attributes common to all top-level container elements of all defined file formats.
+			</xs:documentation>
+		</xs:annotation>
+		<xs:attribute name="author" type="xs:string" use="optional">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
+					This attribute gives the name of the author of this file's content.
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="copyright" type="xs:string" use="optional">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
+					This attribute gives copyright information for this file's content.
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="fileversion" type="xs:normalizedString" use="optional">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
+					This attribute gives a version number for this file's content.
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="generationDateAndTime" type="xs:dateTime">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
+					This attribute gives the date and time this file was generated.
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="generationTool" type="xs:normalizedString">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
+					This attribute gives the name of the tool that generated this file.
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="license" type="xs:string" use="optional">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
+					This attribute gives license information for this file's content.
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:attributeGroup>
+	<xs:complexType mixed="true" name="ContentType">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">
+				This optional element can contain inlined content of an entity. If it is present, then the attribute source of the enclosing element must not be present.
+			</xs:documentation>
+		</xs:annotation>
+		<xs:attributeGroup ref="ssc:ABaseElement"/>
+		<xs:choice>
+			<xs:any maxOccurs="unbounded" minOccurs="0" namespace="##any" processContents="lax"/>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="SignatureType">
+		<xs:attribute default="SSD" name="sourceBase" use="optional">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
+					Defines the base the source URI is resolved against: If the attribute is missing or is specified as SSD, the source is resolved against the URI of the SSD, if the attribute is specified as component the URI is resolved against the (resolved) URI of the model element (e.g. component) source, or if the attribute is specified as metaData the URI is resolved against the (resolved) URI of the meta data source. The value metaData is only valid if the Signature element is contained within a MetaData element.
+				</xs:documentation>
+			</xs:annotation>
+			<xs:simpleType>
+				<xs:restriction base="xs:string">
+					<xs:enumeration value="component"/>
+					<xs:enumeration value="metaData"/>
+					<xs:enumeration value="SSD"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<xs:attribute name="role" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
+					This mandatory attribute specifies the role this signature has in the overall process. It indicates whether the digital signature is intended to just convey the authenticity of the information, or whether a claim for suitability of the information for certain purposes is made. In the later case, the digital signature format should include detailed information about what suitability claims are being made.
+				</xs:documentation>
+			</xs:annotation>
+			<xs:simpleType>
+				<xs:restriction base="xs:string">
+					<xs:enumeration value="authenticity"/>
+					<xs:enumeration value="suitability"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<xs:attribute name="source" type="xs:anyURI" use="optional">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
+					This attribute indicates the source of the digital signature as a URI (cf. RFC 3986). For purposes of the resolution of relative URIs the base URI is the URI of the SSD, if the sourceBase attribute is not specified or is specified as SSD, the URI of the containing model element (e.g. component) if the sourceBase attribute is specified as component, or the URI of the meta data source if the sourceBase attribute is specified as metaData. This allows the specification of signature sources that reside inside the component (for example an FMU), or the meta data through relative URIs. If the source attribute is missing, the signature is provided inline as contents of the Content element, which must not be present otherwise.
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="type" type="xs:string" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
+					This mandatory attribute specifies the MIME type of the resource signature, which does not have a default value. If no specific MIME type can be indicated, then the type application/octet-stream is to be used.
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attributeGroup ref="ssc:ABaseElement"/>
+		<xs:sequence>
+			<xs:element maxOccurs="1" minOccurs="0" name="Content" type="ssc:ContentType"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TAnnotations">
+		<xs:sequence maxOccurs="unbounded">
+			<xs:element name="Annotation">
+				<xs:complexType mixed="true">
+					<xs:attribute name="type" type="xs:normalizedString" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
+								The unique name of the type of the annotation. In order to ensure uniqueness all types should be identified with reverse domain name notation (cf. Java package names or Apple UTIs) of a domain that is controlled by the entity defining the semantics and content of the annotation. For vendor-specific annotations this would e.g. be a domain controlled by the tool vendor. For MAP-SSP defined annotations, this will be a domain under the org.modelica prefix.
+							</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:sequence>
+						<xs:any minOccurs="0" namespace="##any" processContents="lax"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TEnumerations">
+		<xs:sequence>
+			<xs:element maxOccurs="unbounded" minOccurs="1" name="Enumeration" type="ssc:TEnumeration"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TEnumeration">
+		<xs:attribute name="name" type="xs:string" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
+					This attribute specifies the name of the enumeration in the system description, which must be unique within in the system description.
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attributeGroup ref="ssc:ABaseElement"/>
+		<xs:sequence>
+			<xs:element maxOccurs="unbounded" minOccurs="1" name="Item">
+				<xs:complexType>
+					<xs:attribute name="name" type="xs:string" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
+								Name of the Enumeration Item
+							</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="value" type="xs:int" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
+								The Value of the Enumeration Item
+							</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element minOccurs="0" name="Annotations" type="ssc:TAnnotations"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TUnits">
+		<xs:sequence>
+			<xs:element maxOccurs="unbounded" minOccurs="1" name="Unit" type="ssc:TUnit"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TUnit">
+		<xs:attribute name="name" type="xs:string" use="required">
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
+					This attribute specifies the name of the unit in the system description, which must be unique within in the system description.
+				</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attributeGroup ref="ssc:ABaseElement"/>
+		<xs:sequence>
+			<xs:element minOccurs="0" name="Annotations" type="ssc:TAnnotations"/>
+			<xs:element name="BaseUnit">
+				<xs:complexType>
+					<xs:attribute default="0" name="A" type="xs:int">
+						<xs:annotation>
+							<xs:documentation>
+								Exponent of SI base unit "A"
+							</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute default="0" name="cd" type="xs:int">
+						<xs:annotation>
+							<xs:documentation>
+								Exponent of SI base unit "cd"
+							</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute default="0" name="kg" type="xs:int">
+						<xs:annotation>
+							<xs:documentation>
+								Exponent of SI base unit "kg"
+							</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute default="0" name="K" type="xs:int">
+						<xs:annotation>
+							<xs:documentation>
+								Exponent of SI base unit "K"
+							</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute default="0" name="mol" type="xs:int">
+						<xs:annotation>
+							<xs:documentation>
+								Exponent of SI base unit "mol"
+							</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute default="0" name="m" type="xs:int">
+						<xs:annotation>
+							<xs:documentation>
+								Exponent of SI base unit "m"
+							</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute default="0" name="offset" type="xs:double"/>
+					<xs:attribute default="0" name="rad" type="xs:int">
+						<xs:annotation>
+							<xs:documentation>
+								Exponent of SI derived unit "rad"
+							</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute default="0" name="s" type="xs:int">
+						<xs:annotation>
+							<xs:documentation>
+								Exponent of SI base unit "s"
+							</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute default="1" name="factor" type="xs:double"/>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:group name="GDimensions">
+		<xs:sequence>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="Dimension">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">
+						This optional element specifies one dimension of an array connector. If no dimension elements are present in a connector, it is a scalar connector. The number of dimension elements in a connector provides the dimensionality of the array. Either the size or the sizeConnector attributes CAN be present on the element, indicating a fixed size, or a size that depends on the structural parameter or constant referenced by the sizeConnector attribute. If none of the attributes are present, then the size of the dimension is unspecified at the SSD level. If both attributes are present this is considered an error.
+					</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:attribute name="sizeConnector" type="xs:string" use="optional">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
+								This attribute references another connector by name, that gives the size of this dimension of the connector, e.g. a structural parameter or a constant of the underlying component that gives the dimension size.
+							</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="size" type="xs:unsignedLong" use="optional">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
+								This attribute gives the size of this dimension of the connector as a fixed, unchangeable number.
+							</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:group>
+	<xs:group name="GMetaData">
+		<xs:sequence>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="MetaData">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">
+						This element can specify additional meta data for the given resource. Multiple (or no) MetaData elements may be present.
+					</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:attribute default="SSD" name="sourceBase" use="optional">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
+								Defines the base the source URI is resolved against: If the attribute is missing or is specified as SSD, the source is resolved against the URI of the SSD, if the attribute is specified as resource the URI is resolved against the (resolved) URI of the resource source.
+							</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="xs:string">
+								<xs:enumeration value="resource"/>
+								<xs:enumeration value="SSD"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="kind" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
+								This attribute indicates the kind of resource meta data that is referenced, i.e. what role it plays in relation to the resource being described.
+							</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="xs:string">
+								<xs:enumeration value="general"/>
+								<xs:enumeration value="quality"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="source" type="xs:anyURI" use="optional">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
+								This attribute indicates the source of the resource meta data as a URI (cf. RFC 3986). For purposes of the resolution of relative URIs the base URI is the URI of the SSD, if the sourceBase attribute is not specified or is specified as SSD, and the URI of the referenced resource if the sourceBase attribute is specified as resource. This allows the specification of meta data sources that reside inside the resource (e.g. an FMU) through relative URIs. For meta data that are located alongside the STC, relative URIs without scheme and authority can and should be used to specify the meta data sources. For meta data that are packaged inside an SSP that contains this STC, this is mandatory (in this way, the STC URIs remain valid after unpacking the SSP into the filesystem). If the source attribute is missing, the meta data is provided inline as contents of the Content element, which must not be present otherwise.
+							</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="type" type="xs:string" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
+								This mandatory attribute specifies the MIME type of the resource meta data, which does not have a default value. If no specific MIME type can be indicated, then the type application/octet-stream is to be used.
+							</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attributeGroup ref="ssc:ABaseElement"/>
+					<xs:sequence>
+						<xs:element maxOccurs="1" minOccurs="0" name="Content" type="ssc:ContentType">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">
+									This optional element can contain inlined content of the resource meta data. If it is present, then the attribute source of the MetaData element must not be present.
+								</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element maxOccurs="unbounded" minOccurs="0" name="Signature" type="ssc:SignatureType">
+							<xs:annotation>
+								<xs:documentation xml:lang="en">
+									This element can contain digital signature information on the meta data referenced by the enclosing MetaData element. It is left unspecified what types of signatures are used and/or available for now. Multiple or no signature elements may be present.
+								</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element maxOccurs="unbounded" minOccurs="0" name="Signature" type="ssc:SignatureType">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">
+						This element can contain digital signature information on the data referenced by the enclosing element. It is left unspecified what types of signatures are used and/or available for now. Multiple or no signature elements may be present.
+					</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:group>
+	<xs:group name="GTransformationChoice">
+		<xs:annotation>
+			<xs:documentation xml:lang="en">
+				This element specifies the transformation to be applied to a value prior to its use in a connection or parameter mapping.
+			</xs:documentation>
+		</xs:annotation>
+		<xs:choice>
+			<xs:element name="BooleanMappingTransformation">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">
+						This element provides for a transformation of boolean parameter values based on a mapping table and is valid for parameters of boolean type. Each mapping table entry is provided by a MapEntry element.
+					</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element maxOccurs="unbounded" minOccurs="1" name="MapEntry">
+							<xs:complexType>
+								<xs:attribute name="source" type="xs:boolean" use="required">
+									<xs:annotation>
+										<xs:documentation xml:lang="en">
+											This attribute gives the value of the parameter in the parameter source that this entry applies to.
+										</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+								<xs:attribute name="target" type="xs:boolean" use="required">
+									<xs:annotation>
+										<xs:documentation xml:lang="en">
+											This attribute gives the value of the parameter to use when applying it to the system or component that is to be parametrized.
+										</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="EnumerationMappingTransformation">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">
+						This element provides for a transformation of enumeration parameter values based on a mapping table of their enumeration item names and is valid for parameters of enumeration type. Each mapping table entry is provided by a MapEntry element.
+					</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element maxOccurs="unbounded" minOccurs="1" name="MapEntry">
+							<xs:complexType>
+								<xs:attribute name="source" type="xs:string" use="required">
+									<xs:annotation>
+										<xs:documentation xml:lang="en">
+											This attribute gives the value of the parameter in the parameter source that this entry applies to.
+										</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+								<xs:attribute name="target" type="xs:string" use="required">
+									<xs:annotation>
+										<xs:documentation xml:lang="en">
+											This attribute gives the value of the parameter to use when applying it to the system or component that is to be parametrized.
+										</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="IntegerMappingTransformation">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">
+						This element provides for a transformation of integer parameter values based on a mapping table and is valid for parameters of all integer and enumeration types. Each mapping table entry is provided by a MapEntry element.
+					</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element maxOccurs="unbounded" minOccurs="1" name="MapEntry">
+							<xs:complexType>
+								<xs:attribute name="source" type="ssc:TGenericInteger" use="required">
+									<xs:annotation>
+										<xs:documentation xml:lang="en">
+											This attribute gives the value of the parameter in the parameter source that this entry applies to.
+										</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+								<xs:attribute name="target" type="ssc:TGenericInteger" use="required">
+									<xs:annotation>
+										<xs:documentation xml:lang="en">
+											This attribute gives the value of the parameter to use when applying it to the system or component that is to be parametrized.
+										</xs:documentation>
+									</xs:annotation>
+								</xs:attribute>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="LinearTransformation">
+				<xs:annotation>
+					<xs:documentation xml:lang="en">
+						This element provides for a linear transformation to be performed on the parameter values and is valid for parameters of a continuous type.
+					</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:attribute default="0.0" name="offset" type="xs:double" use="optional">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
+								This attribute specifies an optional offset value to use in a linear transformation of the source parameter value to the target parameter value, i.e. in the calculation target = factor * source + offset. Note that conversions based on different units are performed, unless prevented by suppressUnitConversion, prior to the application of the linear transformation, i.e. the value of source is already converted to the target unit in the formula above.
+							</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute default="1.0" name="factor" type="xs:double" use="optional">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
+								This attribute specifies an optional factor value to use in a linear transformation of the source parameter value to the target parameter value, i.e. in the calculation target = factor * source + offset. Note that conversions based on different units are performed, unless prevented by suppressUnitConversion, prior to the application of the linear transformation, i.e. the value of source is already converted to the target unit in the formula above.
+							</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+		</xs:choice>
+	</xs:group>
+	<xs:group name="GTypeChoice">
+		<xs:choice>
+			<xs:annotation>
+				<xs:documentation xml:lang="en">
+					This element gives the type of a connector or signal dictionary entry (called entity below).
+				</xs:documentation>
+			</xs:annotation>
+			<xs:element name="Binary">
+				<xs:complexType>
+					<xs:attribute default="application/octet-stream" name="mime-type" type="xs:string">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
+								This optional attribute specifies the MIME type of the underlying binary data, which defaults to the non-specific application/octet-stream type. This information can be used by the implementation to detect mismatches between connected binary connectors, or provide automatic means of conversion between different formats. It should be noted that the implementation is not required to provide this service, i.e. it remains the responsibility of the operator to ensure only compatible binary connectors are connected.
+							</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Boolean">
+				<xs:complexType/>
+			</xs:element>
+			<xs:element name="Clock">
+				<xs:complexType>
+					<xs:attribute default="0" name="shiftCounter" type="xs:unsignedLong"/>
+					<xs:attribute default="0" name="shiftDecimal" type="xs:double"/>
+					<xs:attribute default="false" name="supportsFraction" type="xs:boolean"/>
+					<xs:attribute name="intervalCounter" type="xs:unsignedLong" use="optional"/>
+					<xs:attribute name="intervalDecimal" type="xs:double" use="optional"/>
+					<xs:attribute name="intervalVariability" use="optional">
+						<xs:simpleType>
+							<xs:restriction base="xs:normalizedString">
+								<xs:enumeration value="changing"/>
+								<xs:enumeration value="constant"/>
+								<xs:enumeration value="countdown"/>
+								<xs:enumeration value="fixed"/>
+								<xs:enumeration value="triggered"/>
+								<xs:enumeration value="tunable"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="priority" type="xs:unsignedInt" use="optional"/>
+					<xs:attribute name="resolution" type="xs:unsignedLong" use="optional"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Enumeration">
+				<xs:complexType>
+					<xs:attribute name="name" type="xs:string" use="required">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
+								This attribute specifies the name of the enumeration which references into the set of defined enumerations of the system structure description, as contained in the Enumerations element of the root element.
+							</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Float32">
+				<xs:complexType>
+					<xs:attribute name="unit" type="xs:string" use="optional">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
+								This attribute gives the unit of the entity and must reference one of the unit definitions provided in the Units element of the containing file. If a unit is not supplied, the unit is determined through default mechanisms: For FMU components, the unit of the underlying variable would be used, for systems the units of connected underlying connectors could be used if unambiguous. If a unit cannot be deduced unambinguously, the user should be informed of this error.
+							</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Float64">
+				<xs:complexType>
+					<xs:attribute name="unit" type="xs:string" use="optional">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
+								This attribute gives the unit of the entity and must reference one of the unit definitions provided in the Units element of the containing file. If a unit is not supplied, the unit is determined through default mechanisms: For FMU components, the unit of the underlying variable would be used, for systems the units of connected underlying connectors could be used if unambiguous. If a unit cannot be deduced unambinguously, the user should be informed of this error.
+							</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="Int16">
+				<xs:complexType/>
+			</xs:element>
+			<xs:element name="Int32">
+				<xs:complexType/>
+			</xs:element>
+			<xs:element name="Int64">
+				<xs:complexType/>
+			</xs:element>
+			<xs:element name="Int8">
+				<xs:complexType/>
+			</xs:element>
+			<xs:element name="Integer">
+				<xs:complexType/>
+			</xs:element>
+			<xs:element name="Real">
+				<xs:complexType>
+					<xs:attribute name="unit" type="xs:string" use="optional">
+						<xs:annotation>
+							<xs:documentation xml:lang="en">
+								This attribute gives the unit of the entity and must reference one of the unit definitions provided in the Units element of the containing file. If a unit is not supplied, the unit is determined through default mechanisms: For FMU components, the unit of the underlying variable would be used, for systems the units of connected underlying connectors could be used if unambiguous. If a unit cannot be deduced unambinguously, the user should be informed of this error.
+							</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="String">
+				<xs:complexType/>
+			</xs:element>
+			<xs:element name="UInt16">
+				<xs:complexType/>
+			</xs:element>
+			<xs:element name="UInt32">
+				<xs:complexType/>
+			</xs:element>
+			<xs:element name="UInt64">
+				<xs:complexType/>
+			</xs:element>
+			<xs:element name="UInt8">
+				<xs:complexType/>
+			</xs:element>
+		</xs:choice>
+	</xs:group>
+	<xs:simpleType name="TGenericInteger">
+		<xs:restriction base="xs:integer">
+			<xs:maxInclusive value="18446744073709551615"/>
+			<xs:minInclusive value="-9223372036854775808"/>
+		</xs:restriction>
+	</xs:simpleType>
 </xs:schema>

--- a/schema/SystemStructureCommon.xsd
+++ b/schema/SystemStructureCommon.xsd
@@ -1,619 +1,822 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema elementFormDefault="qualified" targetNamespace="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:xs="http://www.w3.org/2001/XMLSchema">
-	<xs:annotation>
-		<xs:documentation xml:lang="en">
-			This is the normative XML Schema 1.0 schema for the MAP SSP SystemStructure 2.0 common content across formats. Version: 2.0-alpha Copyright 2016 -- 2019 Modelica Association Project "SSP" Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met: 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer. 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-		</xs:documentation>
-	</xs:annotation>
-	<xs:attributeGroup name="ABaseElement">
-		<xs:annotation>
-			<xs:documentation xml:lang="en">
-				This attribute group specifies the attributes common to all model elements.
-			</xs:documentation>
-		</xs:annotation>
-		<xs:attribute name="description" type="xs:string" use="optional">
-			<xs:annotation>
-				<xs:documentation xml:lang="en">
-					This attribute gives a human readable longer description of the model element, which can be shown to the user where appropriate.
-				</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
-		<xs:attribute name="id" type="xs:ID" use="optional">
-			<xs:annotation>
-				<xs:documentation xml:lang="en">
-					This attribute gives the model element a file-wide unique id which can be referenced from other elements or via URI fragment identifier.
-				</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
-	</xs:attributeGroup>
-	<xs:attributeGroup name="ATopLevelMetaData">
-		<xs:annotation>
-			<xs:documentation xml:lang="en">
-				This attribute group specifies the optional meta-data attributes common to all top-level container elements of all defined file formats.
-			</xs:documentation>
-		</xs:annotation>
-		<xs:attribute name="author" type="xs:string" use="optional">
-			<xs:annotation>
-				<xs:documentation xml:lang="en">
-					This attribute gives the name of the author of this file's content.
-				</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
-		<xs:attribute name="copyright" type="xs:string" use="optional">
-			<xs:annotation>
-				<xs:documentation xml:lang="en">
-					This attribute gives copyright information for this file's content.
-				</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
-		<xs:attribute name="fileversion" type="xs:normalizedString" use="optional">
-			<xs:annotation>
-				<xs:documentation xml:lang="en">
-					This attribute gives a version number for this file's content.
-				</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
-		<xs:attribute name="generationDateAndTime" type="xs:dateTime">
-			<xs:annotation>
-				<xs:documentation xml:lang="en">
-					This attribute gives the date and time this file was generated.
-				</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
-		<xs:attribute name="generationTool" type="xs:normalizedString">
-			<xs:annotation>
-				<xs:documentation xml:lang="en">
-					This attribute gives the name of the tool that generated this file.
-				</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
-		<xs:attribute name="license" type="xs:string" use="optional">
-			<xs:annotation>
-				<xs:documentation xml:lang="en">
-					This attribute gives license information for this file's content.
-				</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
-	</xs:attributeGroup>
-	<xs:complexType mixed="true" name="ContentType">
-		<xs:annotation>
-			<xs:documentation xml:lang="en">
-				This optional element can contain inlined content of an entity. If it is present, then the attribute source of the enclosing element must not be present.
-			</xs:documentation>
-		</xs:annotation>
-		<xs:attributeGroup ref="ssc:ABaseElement"/>
-		<xs:choice>
-			<xs:any maxOccurs="unbounded" minOccurs="0" namespace="##any" processContents="lax"/>
-		</xs:choice>
-	</xs:complexType>
-	<xs:complexType name="SignatureType">
-		<xs:attribute default="SSD" name="sourceBase" use="optional">
-			<xs:annotation>
-				<xs:documentation xml:lang="en">
-					Defines the base the source URI is resolved against: If the attribute is missing or is specified as SSD, the source is resolved against the URI of the SSD, if the attribute is specified as component the URI is resolved against the (resolved) URI of the model element (e.g. component) source, or if the attribute is specified as metaData the URI is resolved against the (resolved) URI of the meta data source. The value metaData is only valid if the Signature element is contained within a MetaData element.
-				</xs:documentation>
-			</xs:annotation>
-			<xs:simpleType>
-				<xs:restriction base="xs:string">
-					<xs:enumeration value="component"/>
-					<xs:enumeration value="metaData"/>
-					<xs:enumeration value="SSD"/>
-				</xs:restriction>
-			</xs:simpleType>
-		</xs:attribute>
-		<xs:attribute name="role" use="required">
-			<xs:annotation>
-				<xs:documentation xml:lang="en">
-					This mandatory attribute specifies the role this signature has in the overall process. It indicates whether the digital signature is intended to just convey the authenticity of the information, or whether a claim for suitability of the information for certain purposes is made. In the later case, the digital signature format should include detailed information about what suitability claims are being made.
-				</xs:documentation>
-			</xs:annotation>
-			<xs:simpleType>
-				<xs:restriction base="xs:string">
-					<xs:enumeration value="authenticity"/>
-					<xs:enumeration value="suitability"/>
-				</xs:restriction>
-			</xs:simpleType>
-		</xs:attribute>
-		<xs:attribute name="source" type="xs:anyURI" use="optional">
-			<xs:annotation>
-				<xs:documentation xml:lang="en">
-					This attribute indicates the source of the digital signature as a URI (cf. RFC 3986). For purposes of the resolution of relative URIs the base URI is the URI of the SSD, if the sourceBase attribute is not specified or is specified as SSD, the URI of the containing model element (e.g. component) if the sourceBase attribute is specified as component, or the URI of the meta data source if the sourceBase attribute is specified as metaData. This allows the specification of signature sources that reside inside the component (for example an FMU), or the meta data through relative URIs. If the source attribute is missing, the signature is provided inline as contents of the Content element, which must not be present otherwise.
-				</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
-		<xs:attribute name="type" type="xs:string" use="required">
-			<xs:annotation>
-				<xs:documentation xml:lang="en">
-					This mandatory attribute specifies the MIME type of the resource signature, which does not have a default value. If no specific MIME type can be indicated, then the type application/octet-stream is to be used.
-				</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
-		<xs:attributeGroup ref="ssc:ABaseElement"/>
-		<xs:sequence>
-			<xs:element maxOccurs="1" minOccurs="0" name="Content" type="ssc:ContentType"/>
-		</xs:sequence>
-	</xs:complexType>
-	<xs:complexType name="TAnnotations">
-		<xs:sequence maxOccurs="unbounded">
-			<xs:element name="Annotation">
-				<xs:complexType mixed="true">
-					<xs:attribute name="type" type="xs:normalizedString" use="required">
-						<xs:annotation>
-							<xs:documentation xml:lang="en">
-								The unique name of the type of the annotation. In order to ensure uniqueness all types should be identified with reverse domain name notation (cf. Java package names or Apple UTIs) of a domain that is controlled by the entity defining the semantics and content of the annotation. For vendor-specific annotations this would e.g. be a domain controlled by the tool vendor. For MAP-SSP defined annotations, this will be a domain under the org.modelica prefix.
-							</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-					<xs:sequence>
-						<xs:any minOccurs="0" namespace="##any" processContents="lax"/>
-					</xs:sequence>
-				</xs:complexType>
-			</xs:element>
-		</xs:sequence>
-	</xs:complexType>
-	<xs:complexType name="TEnumerations">
-		<xs:sequence>
-			<xs:element maxOccurs="unbounded" minOccurs="1" name="Enumeration" type="ssc:TEnumeration"/>
-		</xs:sequence>
-	</xs:complexType>
-	<xs:complexType name="TEnumeration">
-		<xs:attribute name="name" type="xs:string" use="required">
-			<xs:annotation>
-				<xs:documentation xml:lang="en">
-					This attribute specifies the name of the enumeration in the system description, which must be unique within in the system description.
-				</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
-		<xs:attributeGroup ref="ssc:ABaseElement"/>
-		<xs:sequence>
-			<xs:element maxOccurs="unbounded" minOccurs="1" name="Item">
-				<xs:complexType>
-					<xs:attribute name="name" type="xs:string" use="required">
-						<xs:annotation>
-							<xs:documentation xml:lang="en">
-								Name of the Enumeration Item
-							</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-					<xs:attribute name="value" type="xs:int" use="required">
-						<xs:annotation>
-							<xs:documentation xml:lang="en">
-								The Value of the Enumeration Item
-							</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-				</xs:complexType>
-			</xs:element>
-			<xs:element minOccurs="0" name="Annotations" type="ssc:TAnnotations"/>
-		</xs:sequence>
-	</xs:complexType>
-	<xs:complexType name="TUnits">
-		<xs:sequence>
-			<xs:element maxOccurs="unbounded" minOccurs="1" name="Unit" type="ssc:TUnit"/>
-		</xs:sequence>
-	</xs:complexType>
-	<xs:complexType name="TUnit">
-		<xs:attribute name="name" type="xs:string" use="required">
-			<xs:annotation>
-				<xs:documentation xml:lang="en">
-					This attribute specifies the name of the unit in the system description, which must be unique within in the system description.
-				</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
-		<xs:attributeGroup ref="ssc:ABaseElement"/>
-		<xs:sequence>
-			<xs:element minOccurs="0" name="Annotations" type="ssc:TAnnotations"/>
-			<xs:element name="BaseUnit">
-				<xs:complexType>
-					<xs:attribute default="0" name="A" type="xs:int">
-						<xs:annotation>
-							<xs:documentation>
-								Exponent of SI base unit "A"
-							</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-					<xs:attribute default="0" name="cd" type="xs:int">
-						<xs:annotation>
-							<xs:documentation>
-								Exponent of SI base unit "cd"
-							</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-					<xs:attribute default="0" name="kg" type="xs:int">
-						<xs:annotation>
-							<xs:documentation>
-								Exponent of SI base unit "kg"
-							</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-					<xs:attribute default="0" name="K" type="xs:int">
-						<xs:annotation>
-							<xs:documentation>
-								Exponent of SI base unit "K"
-							</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-					<xs:attribute default="0" name="mol" type="xs:int">
-						<xs:annotation>
-							<xs:documentation>
-								Exponent of SI base unit "mol"
-							</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-					<xs:attribute default="0" name="m" type="xs:int">
-						<xs:annotation>
-							<xs:documentation>
-								Exponent of SI base unit "m"
-							</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-					<xs:attribute default="0" name="offset" type="xs:double"/>
-					<xs:attribute default="0" name="rad" type="xs:int">
-						<xs:annotation>
-							<xs:documentation>
-								Exponent of SI derived unit "rad"
-							</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-					<xs:attribute default="0" name="s" type="xs:int">
-						<xs:annotation>
-							<xs:documentation>
-								Exponent of SI base unit "s"
-							</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-					<xs:attribute default="1" name="factor" type="xs:double"/>
-				</xs:complexType>
-			</xs:element>
-		</xs:sequence>
-	</xs:complexType>
-	<xs:group name="GDimensions">
-		<xs:sequence>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="Dimension">
-				<xs:annotation>
-					<xs:documentation xml:lang="en">
-						This optional element specifies one dimension of an array connector. If no dimension elements are present in a connector, it is a scalar connector. The number of dimension elements in a connector provides the dimensionality of the array. Either the size or the sizeConnector attributes CAN be present on the element, indicating a fixed size, or a size that depends on the structural parameter or constant referenced by the sizeConnector attribute. If none of the attributes are present, then the size of the dimension is unspecified at the SSD level. If both attributes are present this is considered an error.
-					</xs:documentation>
-				</xs:annotation>
-				<xs:complexType>
-					<xs:attribute name="sizeConnector" type="xs:string" use="optional">
-						<xs:annotation>
-							<xs:documentation xml:lang="en">
-								This attribute references another connector by name, that gives the size of this dimension of the connector, e.g. a structural parameter or a constant of the underlying component that gives the dimension size.
-							</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-					<xs:attribute name="size" type="xs:unsignedLong" use="optional">
-						<xs:annotation>
-							<xs:documentation xml:lang="en">
-								This attribute gives the size of this dimension of the connector as a fixed, unchangeable number.
-							</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-				</xs:complexType>
-			</xs:element>
-		</xs:sequence>
-	</xs:group>
-	<xs:group name="GMetaData">
-		<xs:sequence>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="MetaData">
-				<xs:annotation>
-					<xs:documentation xml:lang="en">
-						This element can specify additional meta data for the given resource. Multiple (or no) MetaData elements may be present.
-					</xs:documentation>
-				</xs:annotation>
-				<xs:complexType>
-					<xs:attribute default="SSD" name="sourceBase" use="optional">
-						<xs:annotation>
-							<xs:documentation xml:lang="en">
-								Defines the base the source URI is resolved against: If the attribute is missing or is specified as SSD, the source is resolved against the URI of the SSD, if the attribute is specified as resource the URI is resolved against the (resolved) URI of the resource source.
-							</xs:documentation>
-						</xs:annotation>
-						<xs:simpleType>
-							<xs:restriction base="xs:string">
-								<xs:enumeration value="resource"/>
-								<xs:enumeration value="SSD"/>
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attribute name="kind" use="required">
-						<xs:annotation>
-							<xs:documentation xml:lang="en">
-								This attribute indicates the kind of resource meta data that is referenced, i.e. what role it plays in relation to the resource being described.
-							</xs:documentation>
-						</xs:annotation>
-						<xs:simpleType>
-							<xs:restriction base="xs:string">
-								<xs:enumeration value="general"/>
-								<xs:enumeration value="quality"/>
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attribute name="source" type="xs:anyURI" use="optional">
-						<xs:annotation>
-							<xs:documentation xml:lang="en">
-								This attribute indicates the source of the resource meta data as a URI (cf. RFC 3986). For purposes of the resolution of relative URIs the base URI is the URI of the SSD, if the sourceBase attribute is not specified or is specified as SSD, and the URI of the referenced resource if the sourceBase attribute is specified as resource. This allows the specification of meta data sources that reside inside the resource (e.g. an FMU) through relative URIs. For meta data that are located alongside the STC, relative URIs without scheme and authority can and should be used to specify the meta data sources. For meta data that are packaged inside an SSP that contains this STC, this is mandatory (in this way, the STC URIs remain valid after unpacking the SSP into the filesystem). If the source attribute is missing, the meta data is provided inline as contents of the Content element, which must not be present otherwise.
-							</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-					<xs:attribute name="type" type="xs:string" use="required">
-						<xs:annotation>
-							<xs:documentation xml:lang="en">
-								This mandatory attribute specifies the MIME type of the resource meta data, which does not have a default value. If no specific MIME type can be indicated, then the type application/octet-stream is to be used.
-							</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-					<xs:attributeGroup ref="ssc:ABaseElement"/>
-					<xs:sequence>
-						<xs:element maxOccurs="1" minOccurs="0" name="Content" type="ssc:ContentType">
-							<xs:annotation>
-								<xs:documentation xml:lang="en">
-									This optional element can contain inlined content of the resource meta data. If it is present, then the attribute source of the MetaData element must not be present.
-								</xs:documentation>
-							</xs:annotation>
-						</xs:element>
-						<xs:element maxOccurs="unbounded" minOccurs="0" name="Signature" type="ssc:SignatureType">
-							<xs:annotation>
-								<xs:documentation xml:lang="en">
-									This element can contain digital signature information on the meta data referenced by the enclosing MetaData element. It is left unspecified what types of signatures are used and/or available for now. Multiple or no signature elements may be present.
-								</xs:documentation>
-							</xs:annotation>
-						</xs:element>
-					</xs:sequence>
-				</xs:complexType>
-			</xs:element>
-			<xs:element maxOccurs="unbounded" minOccurs="0" name="Signature" type="ssc:SignatureType">
-				<xs:annotation>
-					<xs:documentation xml:lang="en">
-						This element can contain digital signature information on the data referenced by the enclosing element. It is left unspecified what types of signatures are used and/or available for now. Multiple or no signature elements may be present.
-					</xs:documentation>
-				</xs:annotation>
-			</xs:element>
-		</xs:sequence>
-	</xs:group>
-	<xs:group name="GTransformationChoice">
-		<xs:annotation>
-			<xs:documentation xml:lang="en">
-				This element specifies the transformation to be applied to a value prior to its use in a connection or parameter mapping.
-			</xs:documentation>
-		</xs:annotation>
-		<xs:choice>
-			<xs:element name="BooleanMappingTransformation">
-				<xs:annotation>
-					<xs:documentation xml:lang="en">
-						This element provides for a transformation of boolean parameter values based on a mapping table and is valid for parameters of boolean type. Each mapping table entry is provided by a MapEntry element.
-					</xs:documentation>
-				</xs:annotation>
-				<xs:complexType>
-					<xs:sequence>
-						<xs:element maxOccurs="unbounded" minOccurs="1" name="MapEntry">
-							<xs:complexType>
-								<xs:attribute name="source" type="xs:boolean" use="required">
-									<xs:annotation>
-										<xs:documentation xml:lang="en">
-											This attribute gives the value of the parameter in the parameter source that this entry applies to.
-										</xs:documentation>
-									</xs:annotation>
-								</xs:attribute>
-								<xs:attribute name="target" type="xs:boolean" use="required">
-									<xs:annotation>
-										<xs:documentation xml:lang="en">
-											This attribute gives the value of the parameter to use when applying it to the system or component that is to be parametrized.
-										</xs:documentation>
-									</xs:annotation>
-								</xs:attribute>
-							</xs:complexType>
-						</xs:element>
-					</xs:sequence>
-				</xs:complexType>
-			</xs:element>
-			<xs:element name="EnumerationMappingTransformation">
-				<xs:annotation>
-					<xs:documentation xml:lang="en">
-						This element provides for a transformation of enumeration parameter values based on a mapping table of their enumeration item names and is valid for parameters of enumeration type. Each mapping table entry is provided by a MapEntry element.
-					</xs:documentation>
-				</xs:annotation>
-				<xs:complexType>
-					<xs:sequence>
-						<xs:element maxOccurs="unbounded" minOccurs="1" name="MapEntry">
-							<xs:complexType>
-								<xs:attribute name="source" type="xs:string" use="required">
-									<xs:annotation>
-										<xs:documentation xml:lang="en">
-											This attribute gives the value of the parameter in the parameter source that this entry applies to.
-										</xs:documentation>
-									</xs:annotation>
-								</xs:attribute>
-								<xs:attribute name="target" type="xs:string" use="required">
-									<xs:annotation>
-										<xs:documentation xml:lang="en">
-											This attribute gives the value of the parameter to use when applying it to the system or component that is to be parametrized.
-										</xs:documentation>
-									</xs:annotation>
-								</xs:attribute>
-							</xs:complexType>
-						</xs:element>
-					</xs:sequence>
-				</xs:complexType>
-			</xs:element>
-			<xs:element name="IntegerMappingTransformation">
-				<xs:annotation>
-					<xs:documentation xml:lang="en">
-						This element provides for a transformation of integer parameter values based on a mapping table and is valid for parameters of all integer and enumeration types. Each mapping table entry is provided by a MapEntry element.
-					</xs:documentation>
-				</xs:annotation>
-				<xs:complexType>
-					<xs:sequence>
-						<xs:element maxOccurs="unbounded" minOccurs="1" name="MapEntry">
-							<xs:complexType>
-								<xs:attribute name="source" type="ssc:TGenericInteger" use="required">
-									<xs:annotation>
-										<xs:documentation xml:lang="en">
-											This attribute gives the value of the parameter in the parameter source that this entry applies to.
-										</xs:documentation>
-									</xs:annotation>
-								</xs:attribute>
-								<xs:attribute name="target" type="ssc:TGenericInteger" use="required">
-									<xs:annotation>
-										<xs:documentation xml:lang="en">
-											This attribute gives the value of the parameter to use when applying it to the system or component that is to be parametrized.
-										</xs:documentation>
-									</xs:annotation>
-								</xs:attribute>
-							</xs:complexType>
-						</xs:element>
-					</xs:sequence>
-				</xs:complexType>
-			</xs:element>
-			<xs:element name="LinearTransformation">
-				<xs:annotation>
-					<xs:documentation xml:lang="en">
-						This element provides for a linear transformation to be performed on the parameter values and is valid for parameters of a continuous type.
-					</xs:documentation>
-				</xs:annotation>
-				<xs:complexType>
-					<xs:attribute default="0.0" name="offset" type="xs:double" use="optional">
-						<xs:annotation>
-							<xs:documentation xml:lang="en">
-								This attribute specifies an optional offset value to use in a linear transformation of the source parameter value to the target parameter value, i.e. in the calculation target = factor * source + offset. Note that conversions based on different units are performed, unless prevented by suppressUnitConversion, prior to the application of the linear transformation, i.e. the value of source is already converted to the target unit in the formula above.
-							</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-					<xs:attribute default="1.0" name="factor" type="xs:double" use="optional">
-						<xs:annotation>
-							<xs:documentation xml:lang="en">
-								This attribute specifies an optional factor value to use in a linear transformation of the source parameter value to the target parameter value, i.e. in the calculation target = factor * source + offset. Note that conversions based on different units are performed, unless prevented by suppressUnitConversion, prior to the application of the linear transformation, i.e. the value of source is already converted to the target unit in the formula above.
-							</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-				</xs:complexType>
-			</xs:element>
-		</xs:choice>
-	</xs:group>
-	<xs:group name="GTypeChoice">
-		<xs:choice>
-			<xs:annotation>
-				<xs:documentation xml:lang="en">
-					This element gives the type of a connector or signal dictionary entry (called entity below).
-				</xs:documentation>
-			</xs:annotation>
-			<xs:element name="Binary">
-				<xs:complexType>
-					<xs:attribute default="application/octet-stream" name="mime-type" type="xs:string">
-						<xs:annotation>
-							<xs:documentation xml:lang="en">
-								This optional attribute specifies the MIME type of the underlying binary data, which defaults to the non-specific application/octet-stream type. This information can be used by the implementation to detect mismatches between connected binary connectors, or provide automatic means of conversion between different formats. It should be noted that the implementation is not required to provide this service, i.e. it remains the responsibility of the operator to ensure only compatible binary connectors are connected.
-							</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-				</xs:complexType>
-			</xs:element>
-			<xs:element name="Boolean">
-				<xs:complexType/>
-			</xs:element>
-			<xs:element name="Clock">
-				<xs:complexType>
-					<xs:attribute default="0" name="shiftCounter" type="xs:unsignedLong"/>
-					<xs:attribute default="0" name="shiftDecimal" type="xs:double"/>
-					<xs:attribute default="false" name="supportsFraction" type="xs:boolean"/>
-					<xs:attribute name="intervalCounter" type="xs:unsignedLong" use="optional"/>
-					<xs:attribute name="intervalDecimal" type="xs:double" use="optional"/>
-					<xs:attribute name="intervalVariability" use="optional">
-						<xs:simpleType>
-							<xs:restriction base="xs:normalizedString">
-								<xs:enumeration value="changing"/>
-								<xs:enumeration value="constant"/>
-								<xs:enumeration value="countdown"/>
-								<xs:enumeration value="fixed"/>
-								<xs:enumeration value="triggered"/>
-								<xs:enumeration value="tunable"/>
-							</xs:restriction>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attribute name="priority" type="xs:unsignedInt" use="optional"/>
-					<xs:attribute name="resolution" type="xs:unsignedLong" use="optional"/>
-				</xs:complexType>
-			</xs:element>
-			<xs:element name="Enumeration">
-				<xs:complexType>
-					<xs:attribute name="name" type="xs:string" use="required">
-						<xs:annotation>
-							<xs:documentation xml:lang="en">
-								This attribute specifies the name of the enumeration which references into the set of defined enumerations of the system structure description, as contained in the Enumerations element of the root element.
-							</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-				</xs:complexType>
-			</xs:element>
-			<xs:element name="Float32">
-				<xs:complexType>
-					<xs:attribute name="unit" type="xs:string" use="optional">
-						<xs:annotation>
-							<xs:documentation xml:lang="en">
-								This attribute gives the unit of the entity and must reference one of the unit definitions provided in the Units element of the containing file. If a unit is not supplied, the unit is determined through default mechanisms: For FMU components, the unit of the underlying variable would be used, for systems the units of connected underlying connectors could be used if unambiguous. If a unit cannot be deduced unambinguously, the user should be informed of this error.
-							</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-				</xs:complexType>
-			</xs:element>
-			<xs:element name="Float64">
-				<xs:complexType>
-					<xs:attribute name="unit" type="xs:string" use="optional">
-						<xs:annotation>
-							<xs:documentation xml:lang="en">
-								This attribute gives the unit of the entity and must reference one of the unit definitions provided in the Units element of the containing file. If a unit is not supplied, the unit is determined through default mechanisms: For FMU components, the unit of the underlying variable would be used, for systems the units of connected underlying connectors could be used if unambiguous. If a unit cannot be deduced unambinguously, the user should be informed of this error.
-							</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-				</xs:complexType>
-			</xs:element>
-			<xs:element name="Int16">
-				<xs:complexType/>
-			</xs:element>
-			<xs:element name="Int32">
-				<xs:complexType/>
-			</xs:element>
-			<xs:element name="Int64">
-				<xs:complexType/>
-			</xs:element>
-			<xs:element name="Int8">
-				<xs:complexType/>
-			</xs:element>
-			<xs:element name="Integer">
-				<xs:complexType/>
-			</xs:element>
-			<xs:element name="Real">
-				<xs:complexType>
-					<xs:attribute name="unit" type="xs:string" use="optional">
-						<xs:annotation>
-							<xs:documentation xml:lang="en">
-								This attribute gives the unit of the entity and must reference one of the unit definitions provided in the Units element of the containing file. If a unit is not supplied, the unit is determined through default mechanisms: For FMU components, the unit of the underlying variable would be used, for systems the units of connected underlying connectors could be used if unambiguous. If a unit cannot be deduced unambinguously, the user should be informed of this error.
-							</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-				</xs:complexType>
-			</xs:element>
-			<xs:element name="String">
-				<xs:complexType/>
-			</xs:element>
-			<xs:element name="UInt16">
-				<xs:complexType/>
-			</xs:element>
-			<xs:element name="UInt32">
-				<xs:complexType/>
-			</xs:element>
-			<xs:element name="UInt64">
-				<xs:complexType/>
-			</xs:element>
-			<xs:element name="UInt8">
-				<xs:complexType/>
-			</xs:element>
-		</xs:choice>
-	</xs:group>
-	<xs:simpleType name="TGenericInteger">
-		<xs:restriction base="xs:integer">
-			<xs:maxInclusive value="18446744073709551615"/>
-			<xs:minInclusive value="-9223372036854775808"/>
-		</xs:restriction>
-	</xs:simpleType>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+    xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+    targetNamespace="http://ssp-standard.org/SSP1/SystemStructureCommon">
+    <xs:annotation>
+        <xs:documentation xml:lang="en">
+            This is the normative XML Schema 1.0 schema for the MAP SSP
+            SystemStructure 2.0 common content across formats.
+            
+            Version: 2.0-alpha
+
+            Copyright 2016 -- 2019 Modelica Association Project "SSP"
+
+            Redistribution and use in source and binary forms, with or
+            without modification, are permitted provided that the
+            following conditions are met:
+
+            1. Redistributions of source code must retain the above
+               copyright notice, this list of conditions and the
+               following disclaimer.
+
+            2. Redistributions in binary form must reproduce the above
+               copyright notice, this list of conditions and the
+               following disclaimer in the documentation and/or other
+               materials provided with the distribution.
+
+            THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+            CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+            INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+            MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+            DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+            CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+            INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+            (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+            GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+            BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+            LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+            (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+            OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+            POSSIBILITY OF SUCH DAMAGE.
+        </xs:documentation>
+    </xs:annotation>
+    
+    <xs:attributeGroup name="ABaseElement">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                This attribute group specifies the attributes common to all model elements.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="id" type="xs:ID" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This attribute gives the model element a file-wide unique id which can
+                    be referenced from other elements or via URI fragment identifier.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="description" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This attribute gives a human readable longer description of the
+                    model element, which can be shown to the user where appropriate. 
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+    
+    <xs:attributeGroup name="ATopLevelMetaData">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                This attribute group specifies the optional meta-data attributes common to 
+                all top-level container elements of all defined file formats.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="author" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This attribute gives the name of the author of this file's content. 
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="fileversion" type="xs:normalizedString" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This attribute gives a version number for this file's content. 
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="copyright" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This attribute gives copyright information for this file's content. 
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="license" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This attribute gives license information for this file's content. 
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="generationTool" type="xs:normalizedString">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This attribute gives the name of the tool that generated this file. 
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="generationDateAndTime" type="xs:dateTime">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This attribute gives the date and time this file was generated. 
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+    
+    <xs:simpleType name="TGenericInteger">
+        <xs:restriction base="xs:integer">
+            <xs:maxInclusive value="18446744073709551615"/>
+            <xs:minInclusive value="-9223372036854775808"/>
+        </xs:restriction>
+    </xs:simpleType>
+    
+    <xs:complexType name="TEnumerations">
+        <xs:sequence>
+            <xs:element name="Enumeration" minOccurs="1" maxOccurs="unbounded" type="ssc:TEnumeration"/>
+        </xs:sequence>
+    </xs:complexType>
+    
+    <xs:complexType name="TEnumeration">
+        <xs:sequence>
+            <xs:element name="Item" minOccurs="1" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">Name of the Enumeration Item</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="value" type="xs:int" use="required">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">The Value of the Enumeration Item</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
+        </xs:sequence>
+        <xs:attributeGroup ref="ssc:ABaseElement"/>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This attribute specifies the name of the enumeration in the system description,
+                    which must be unique within in the system description.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+    
+    <xs:complexType name="TUnits">
+        <xs:sequence>
+            <xs:element name="Unit" minOccurs="1" maxOccurs="unbounded" type="ssc:TUnit"/>
+        </xs:sequence>
+    </xs:complexType>
+    
+    <xs:complexType name="TUnit">
+        <xs:sequence>
+            <xs:element name="BaseUnit">
+                <xs:complexType>
+                    <xs:attribute name="kg" type="xs:int" default="0">
+                        <xs:annotation>
+                            <xs:documentation>Exponent of SI base unit "kg"</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="m" type="xs:int" default="0">
+                        <xs:annotation>
+                            <xs:documentation>Exponent of SI base unit "m"</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="s" type="xs:int" default="0">
+                        <xs:annotation>
+                            <xs:documentation>Exponent of SI base unit "s"</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="A" type="xs:int" default="0">
+                        <xs:annotation>
+                            <xs:documentation>Exponent of SI base unit "A"</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="K" type="xs:int" default="0">
+                        <xs:annotation>
+                            <xs:documentation>Exponent of SI base unit "K"</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="mol" type="xs:int" default="0">
+                        <xs:annotation>
+                            <xs:documentation>Exponent of SI base unit "mol"</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="cd" type="xs:int" default="0">
+                        <xs:annotation>
+                            <xs:documentation>Exponent of SI base unit "cd"</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="rad" type="xs:int" default="0">
+                        <xs:annotation>
+                            <xs:documentation>Exponent of SI derived unit "rad"</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="factor" type="xs:double" default="1"/>
+                    <xs:attribute name="offset" type="xs:double" default="0"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
+        </xs:sequence>
+        <xs:attributeGroup ref="ssc:ABaseElement"/>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This attribute specifies the name of the unit in the system description,
+                    which must be unique within in the system description.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+    
+    <xs:complexType name="TAnnotations">
+        <xs:sequence maxOccurs="unbounded">
+            <xs:element name="Annotation">
+                <xs:complexType mixed="true">
+                    <xs:sequence>
+                        <xs:any namespace="##any" processContents="lax" minOccurs="0"/>
+                    </xs:sequence>
+                    <xs:attribute name="type" type="xs:normalizedString" use="required">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                The unique name of the type of the annotation.
+                                
+                                In order to ensure uniqueness all types should be identified
+                                with reverse domain name notation (cf. Java package names
+                                or Apple UTIs) of a domain that is controlled by the entity
+                                defining the semantics and content of the annotation.
+                                
+                                For vendor-specific annotations this would e.g. be a domain
+                                controlled by the tool vendor.
+                                
+                                For MAP-SSP defined annotations, this will be a domain under
+                                the org.modelica prefix.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    
+    <xs:group name="GMetaData">
+        <xs:sequence>
+            <xs:element name="MetaData" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        This element can specify additional meta data for the given resource. Multiple
+                        (or no) MetaData elements may be present.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="Content" type="ssc:ContentType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This optional element can contain inlined content of the resource meta data. If it
+                                    is present, then the attribute source of the MetaData element must not be present.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:element name="Signature" type="ssc:SignatureType" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This element can contain digital signature information on the meta data referenced
+                                    by the enclosing MetaData element. It is left unspecified what types of signatures
+                                    are used and/or available for now.  Multiple or no signature elements may be present.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                    </xs:sequence>
+                    <xs:attribute name="kind" use="required">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute indicates the kind of resource meta data that is referenced, i.e.
+                                what role it plays in relation to the resource being described.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="general"/>
+                                <xs:enumeration value="quality"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attribute name="type" type="xs:string" use="required">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This mandatory attribute specifies the MIME type of the resource meta data, which
+                                does not have a default value.  If no specific MIME type can be indicated, then
+                                the type application/octet-stream is to be used.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="source" type="xs:anyURI" use="optional">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute indicates the source of the resource meta data as a
+                                URI (cf. RFC 3986).  For purposes of the resolution of relative URIs
+                                the base URI is the URI of the SSD, if the sourceBase attribute is
+                                not specified or is specified as SSD, and the URI of the referenced
+                                resource if the sourceBase attribute is specified as resource.
+                                
+                                This allows the specification of meta data sources that reside
+                                inside the resource (e.g. an FMU) through relative URIs.
+                                
+                                For meta data that are located alongside the SSD, relative URIs
+                                without scheme and authority can and should be used to specify the
+                                meta data sources.  For meta data that are packaged inside an SSP
+                                that contains this SSD, this is mandatory (in this way, the SSD
+                                URIs remain valid after unpacking the SSP into the filesystem).
+                                
+                                If the source attribute is missing, the meta data is provided
+                                inline as contents of the Content element, which must not be
+                                present otherwise.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="sourceBase" use="optional" default="SSD">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                Defines the base the source URI is resolved against:  If the attribute
+                                is missing or is specified as SSD, the source is resolved against the
+                                URI of the SSD, if the attribute is specified as resource the URI is
+                                resolved against the (resolved) URI of the resource source.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="SSD"/>
+                                <xs:enumeration value="resource"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attributeGroup ref="ssc:ABaseElement"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Signature" type="ssc:SignatureType" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        This element can contain digital signature information on the data referenced
+                        by the enclosing element. It is left unspecified what types of signatures
+                        are used and/or available for now.  Multiple or no signature elements may be present.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:group>
+
+    <xs:complexType name="SignatureType">
+        <xs:sequence>
+            <xs:element name="Content" type="ssc:ContentType" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="role" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This mandatory attribute specifies the role this signature has in the overall
+                    process. It indicates whether the digital signature is intended to just convey
+                    the authenticity of the information, or whether a claim for suitability of
+                    the information for certain purposes is made.  In the later case, the digital
+                    signature format should include detailed information about what suitability
+                    claims are being made.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="authenticity"/>
+                    <xs:enumeration value="suitability"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="type" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This mandatory attribute specifies the MIME type of the resource signature, which
+                    does not have a default value.  If no specific MIME type can be indicated, then
+                    the type application/octet-stream is to be used.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="source" type="xs:anyURI" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This attribute indicates the source of the digital signature as a
+                    URI (cf. RFC 3986).  For purposes of the resolution of relative URIs
+                    the base URI is the URI of the SSD, if the sourceBase attribute is
+                    not specified or is specified as SSD, the URI of the  containing model
+                    element (e.g. component) if the sourceBase attribute is specified as
+                    component, or the URI of the meta data source if the sourceBase
+                    attribute is specified as metaData.
+                    
+                    This allows the specification of signature sources that reside
+                    inside the component (for example an FMU), or the meta data
+                    through relative URIs.
+                    
+                    If the source attribute is missing, the signature is provided
+                    inline as contents of the Content element, which must not be
+                    present otherwise.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="sourceBase" use="optional" default="SSD">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    Defines the base the source URI is resolved against: If the attribute
+                    is missing or is specified as SSD, the source is resolved against the
+                    URI of the SSD, if the attribute is specified as component the URI is
+                    resolved against the (resolved) URI of the model element (e.g.
+                    component) source, or if the attribute is specified as metaData the
+                    URI is resolved against the (resolved) URI of the meta data source.
+                    The value metaData is only valid if the Signature element is contained
+                    within a MetaData element.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="SSD"/>
+                    <xs:enumeration value="component"/>
+                    <xs:enumeration value="metaData"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attributeGroup ref="ssc:ABaseElement"/>
+    </xs:complexType>
+
+    <xs:complexType name="ContentType" mixed="true">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                This optional element can contain inlined content of an entity. If it is present,
+                then the attribute source of the enclosing element must not be present.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice>
+            <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:choice>
+        <xs:attributeGroup ref="ssc:ABaseElement"/>
+    </xs:complexType>
+
+    <xs:group name="GTypeChoice">
+        <xs:choice>
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This element gives the type of a connector or signal dictionary entry
+                    (called entity below).
+                </xs:documentation>
+            </xs:annotation>
+            <xs:element name="Real">
+                <xs:complexType>
+                    <xs:attribute name="unit" type="xs:string" use="optional">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute gives the unit of the entity and must
+                                reference one of the unit definitions provided in the Units
+                                element of the containing file.
+                                
+                                If a unit is not supplied, the unit is determined through
+                                default mechanisms: For FMU components, the unit of the
+                                underlying variable would be used, for systems the units
+                                of connected underlying connectors could be used if unambiguous.
+                                If a unit cannot be deduced unambinguously, the user should
+                                be informed of this error.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Float64">
+                <xs:complexType>
+                    <xs:attribute name="unit" type="xs:string" use="optional">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute gives the unit of the entity and must
+                                reference one of the unit definitions provided in the Units
+                                element of the containing file.
+                                
+                                If a unit is not supplied, the unit is determined through
+                                default mechanisms: For FMU components, the unit of the
+                                underlying variable would be used, for systems the units
+                                of connected underlying connectors could be used if unambiguous.
+                                If a unit cannot be deduced unambinguously, the user should
+                                be informed of this error.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Float32">
+                <xs:complexType>
+                    <xs:attribute name="unit" type="xs:string" use="optional">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute gives the unit of the entity and must
+                                reference one of the unit definitions provided in the Units
+                                element of the containing file.
+                                
+                                If a unit is not supplied, the unit is determined through
+                                default mechanisms: For FMU components, the unit of the
+                                underlying variable would be used, for systems the units
+                                of connected underlying connectors could be used if unambiguous.
+                                If a unit cannot be deduced unambinguously, the user should
+                                be informed of this error.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Integer">
+                <xs:complexType>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Int8">
+                <xs:complexType>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="UInt8">
+                <xs:complexType>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Int16">
+                <xs:complexType>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="UInt16">
+                <xs:complexType>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Int32">
+                <xs:complexType>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="UInt32">
+                <xs:complexType>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Int64">
+                <xs:complexType>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="UInt64">
+                <xs:complexType>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Boolean">
+                <xs:complexType>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="String">
+                <xs:complexType>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Enumeration">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute specifies the name of the enumeration
+                                which references into the set of defined enumerations
+                                of the system structure description, as contained in
+                                the Enumerations element of the root element.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Binary">
+                <xs:complexType>
+                    <xs:attribute name="mime-type" type="xs:string" default="application/octet-stream">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This optional attribute specifies the MIME type of the
+                                underlying binary data, which defaults to the non-specific
+                                application/octet-stream type.  This information can be
+                                used by the implementation to detect mismatches between
+                                connected binary connectors, or provide automatic means of
+                                conversion between different formats.  It should be noted
+                                that the implementation is not required to provide this
+                                service, i.e. it remains the responsibility of the operator 
+                                to ensure only compatible binary connectors are connected.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Clock">
+                <xs:complexType>
+                  <xs:attribute name="intervalVariability" use="optional">
+                    <xs:simpleType>
+                      <xs:restriction base="xs:normalizedString">
+                        <xs:enumeration value="constant"/>
+                        <xs:enumeration value="fixed"/>
+                        <xs:enumeration value="tunable"/>
+                        <xs:enumeration value="changing"/>
+                        <xs:enumeration value="countdown"/>
+                        <xs:enumeration value="triggered"/>
+                      </xs:restriction>
+                    </xs:simpleType>
+                  </xs:attribute>
+                  <xs:attribute name="intervalDecimal" type="xs:double" use="optional"/>
+                  <xs:attribute name="shiftDecimal" type="xs:double" default="0"/>
+                  <xs:attribute name="supportsFraction" type="xs:boolean" default="false"/>
+                  <xs:attribute name="resolution" type="xs:unsignedLong" use="optional"/>
+                  <xs:attribute name="intervalCounter" type="xs:unsignedLong" use="optional"/>
+                  <xs:attribute name="shiftCounter" type="xs:unsignedLong" default="0"/>
+                  <xs:attribute name="priority" type="xs:unsignedInt" use="optional"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:choice>
+    </xs:group>
+    
+    <xs:group name="GTransformationChoice">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                This element specifies the transformation to be applied to a value prior to its
+                use in a connection or parameter mapping.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice>
+            <xs:element name="LinearTransformation">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        This element provides for a linear transformation to be performed on the
+                        parameter values and is valid for parameters of a continuous type.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:attribute name="factor" type="xs:double" use="optional" default="1.0">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute specifies an optional factor value to use in a linear
+                                transformation of the source parameter value to the target parameter
+                                value, i.e. in the calculation target = factor * source + offset.
+                                
+                                Note that conversions based on different units are performed, unless
+                                prevented by suppressUnitConversion, prior to the application of the
+                                linear transformation, i.e. the value of source is already converted
+                                to the target unit in the formula above.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="offset" type="xs:double" use="optional" default="0.0">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute specifies an optional offset value to use in a linear
+                                transformation of the source parameter value to the target parameter
+                                value, i.e. in the calculation target = factor * source + offset.
+                                
+                                Note that conversions based on different units are performed, unless
+                                prevented by suppressUnitConversion, prior to the application of the
+                                linear transformation, i.e. the value of source is already converted
+                                to the target unit in the formula above.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="BooleanMappingTransformation">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        This element provides for a transformation of boolean parameter values
+                        based on a mapping table and is valid for parameters of boolean type.
+                        Each mapping table entry is provided by a MapEntry element.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="MapEntry" minOccurs="1" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:attribute name="source" type="xs:boolean" use="required">
+                                    <xs:annotation>
+                                        <xs:documentation xml:lang="en">
+                                            This attribute gives the value of the parameter in the
+                                            parameter source that this entry applies to.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="target" type="xs:boolean" use="required">
+                                    <xs:annotation>
+                                        <xs:documentation xml:lang="en">
+                                            This attribute gives the value of the parameter to use
+                                            when applying it to the system or component that is to be
+                                            parametrized.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="IntegerMappingTransformation">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        This element provides for a transformation of integer parameter values
+                        based on a mapping table and is valid for parameters of all integer and 
+                        enumeration types.  Each mapping table entry is provided by a MapEntry
+                        element.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="MapEntry" minOccurs="1" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:attribute name="source" type="ssc:TGenericInteger" use="required">
+                                    <xs:annotation>
+                                        <xs:documentation xml:lang="en">
+                                            This attribute gives the value of the parameter in the
+                                            parameter source that this entry applies to.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="target" type="ssc:TGenericInteger" use="required">
+                                    <xs:annotation>
+                                        <xs:documentation xml:lang="en">
+                                            This attribute gives the value of the parameter to use
+                                            when applying it to the system or component that is to be
+                                            parametrized.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="EnumerationMappingTransformation">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        This element provides for a transformation of enumeration parameter values
+                        based on a mapping table of their enumeration item names and is valid for
+                        parameters of enumeration type.  Each mapping table entry is provided by a
+                        MapEntry element.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="MapEntry" minOccurs="1" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:attribute name="source" type="xs:string" use="required">
+                                    <xs:annotation>
+                                        <xs:documentation xml:lang="en">
+                                            This attribute gives the value of the parameter in the
+                                            parameter source that this entry applies to.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="target" type="xs:string" use="required">
+                                    <xs:annotation>
+                                        <xs:documentation xml:lang="en">
+                                            This attribute gives the value of the parameter to use
+                                            when applying it to the system or component that is to be
+                                            parametrized.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:choice>
+    </xs:group>
+    
+    <xs:group name="GDimensions">
+        <xs:sequence>
+            <xs:element name="Dimension" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        This optional element specifies one dimension of an array connector.
+                        If no dimension elements are present in a connector, it is a scalar
+                        connector. The number of dimension elements in a connector provides
+                        the dimensionality of the array.
+                        
+                        Either the size or the sizeConnector attributes CAN be present
+                        on the element, indicating a fixed size, or a size that depends on
+                        the structural parameter or constant referenced by the sizeConnector
+                        attribute.
+                        
+                        If none of the attributes are present, then the size of the dimension
+                        is unspecified at the SSD level. If both attributes are present this
+                        is considered an error.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:attribute name="size" type="xs:unsignedLong" use="optional">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute gives the size of this dimension of the
+                                connector as a fixed, unchangeable number.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="sizeConnector" type="xs:string" use="optional">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute references another connector by name, that
+                                gives the size of this dimension of the connector, e.g. a
+                                structural parameter or a constant of the underlying
+                                component that gives the dimension size.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:group>
+    
 </xs:schema>


### PR DESCRIPTION
* Reference of FMI 3.0
* Description for attribute MetaData.source and MetaData.sourceBase changed -> STC replaced by SSD.