### PR TITLE
Fix schema for value attribute of Binary/Enumeration

### DIFF
--- a/schema/SystemStructureParameterValues.xsd
+++ b/schema/SystemStructureParameterValues.xsd
@@ -361,7 +361,7 @@
                                     </xs:documentation>
                                 </xs:annotation>
                                 <xs:complexType>
-                                    <xs:attribute name="value" type="xs:string" use="required"/>
+                                    <xs:attribute name="value" type="xs:string"/>
                                 </xs:complexType>
                             </xs:element>
                         </xs:sequence>
@@ -417,7 +417,7 @@
                                     </xs:documentation>
                                 </xs:annotation>
                                 <xs:complexType>
-                                    <xs:attribute name="value" type="xs:hexBinary" use="required"/>
+                                    <xs:attribute name="value" type="xs:hexBinary"/>
                                 </xs:complexType>
                             </xs:element>
                         </xs:sequence>


### PR DESCRIPTION
These attributes are no longer required, as alternatively the Value elements can be used, hence the attribute cannot be declared as required.