### PR TITLE
Add justification for SSP "size" vs FMI "start" attribute naming

### DIFF
--- a/docs/4___common_content.adoc
+++ b/docs/4___common_content.adoc
@@ -476,7 +476,7 @@ This attribute gives the size of this dimension of the array as a fixed, unchang
 This attribute references another connector by name, that gives the size of this dimension of the array connector, e.g. a structural parameter or a constant of the underlying component that gives the dimension size.
 |===
 
-{empty}[ _SSP uses `size` where FMI uses `start` because SSP specifies structural dimension extents directly, while FMI's `start` denotes initial values that determine dimensions._ ]
+{empty}[ _SSP uses `size` where FMI uses `start` because SSP specifies structural dimension extents directly._ ]
 
 [#ssc_metadata]
 ==== MetaData Sequence


### PR DESCRIPTION
Closes #67