### PR TITLE
Fix SSP relationship to FMI as complementary standard

### DIFF
--- a/docs/1___overview.adoc
+++ b/docs/1___overview.adoc
@@ -4,7 +4,7 @@ SSP is a tool-independent format for the description, packaging and exchange of 
 The standard is comprised of a set of XML-based formats to describe a network of component models with their signal flow and parameterization, as well as a ZIP-based packaging format for efficient distribution of entire systems, including any referenced models and other resources.
 This description is tool neutral and is intended to be used primarily as an exchange format of simulation system descriptions between different tools.
 
-SSP can be seen as an extension to the FMI (Functional Mockup Interface) standard [<<FMI30>>].
+SSP can be seen as a complementary standard to the FMI (Functional Mockup Interface) standard [<<FMI30>>], designed for compatibility with FMI and Modelica while maintaining generic applicability.
 FMI describes a tool independent standard to exchange single simulation models.
 Using SSP, complete systems consisting of multiple interconnected simulation models can be defined with the desired signal flow and also with the wanted parameterization of each single model as well as the parameters for the complete system.
 This system topology can include hierarchies of sub-systems for proper structuring of the overall system.


### PR DESCRIPTION
I think the wording "SSP can be seen as an extension to the FMI..." is misleading.
SSP is not an extension to FMI. The FMI-layered-standards are extensions to FMI, while SSP-layered-standards are extensions to SSP.
SSP is a "complementary standard" to FMI.