### PR TITLE
Add terminal support

### DIFF
--- a/docs/4___common_content.adoc
+++ b/docs/4___common_content.adoc
@@ -179,7 +179,7 @@ The following XML child elements denote the data type of a connector or dictiona
 |Real / Float64 / Float32 / +
 Integer / Int8 / UInt8 / Int16 / UInt16 / +
 Int32 / UInt32 / Int64 / UInt64 / +
-Boolean / String / Enumeration / Binary / Clock |Exactly one of these elements *MUST* be present to specify the type of the element.
+Boolean / String / Enumeration / Binary / Clock / Terminal |Exactly one of these elements *MUST* be present to specify the type of the element.
 See below for details.
 |===
 
@@ -382,6 +382,21 @@ Default is 0.
 |priority
 a|This optional attribute specifies the execution priority of the clock for scheduling purposes.
 Lower values indicate higher priority.
+|===
+
+===== Terminal
+
+image:images/SystemStructureCommon_Terminal.svg[image]
+
+This type specifies that the connector in question represents a structured terminal, compatible with FMI 3.0 terminals.
+It *MUST* only be used for connectors of kind `terminal`. For detailed terminal semantics and behavior, refer to the FMI 3.0 specification.
+
+[width="100%",cols="28%,72%",options="header",]
+|===
+|Attribute |Description
+|name |This required attribute references a terminal type definition by name.
+The name *MUST* match the name of a Terminal entry in the Terminals XML element of the top-level SystemStructureDescription element.
+The member-to-variable binding follows the naming convention `connectorName.memberName`.
 |===
 
 [#ssc_transformations]

--- a/docs/4___common_content.adoc
+++ b/docs/4___common_content.adoc
@@ -388,15 +388,36 @@ Lower values indicate higher priority.
 
 image:images/SystemStructureCommon_Terminal.svg[image]
 
-This type specifies that the connector in question represents a structured terminal, compatible with FMI 3.0 terminals.
-It *MUST* only be used for connectors of kind `terminal`. For detailed terminal semantics and behavior, refer to the FMI 3.0 specification.
+This type specifies that the connector in question represents a structured terminal.
+It *MUST* only be used for connectors of kind `terminal`.
+
+Two usage patterns are supported:
+
+1. *Global type reference*: provide only the `name` attribute, which references a `Terminal` definition in the `Terminals` section of the enclosing `SystemStructureDescription`.
+The connector names defined in the referenced `Terminal` definition are used directly as the variable names in the component; no separate variable name mapping is required.
+2. *Inline definition*: omit the `name` attribute and provide `matchingRule` together with a `Connectors` child element.
+Each `Connector` child defines a connector by `name` and optional `kind`; the connector name is used directly as the variable name in the component.
+`kind` may be omitted in inline definitions when direction is not relevant or not yet determined.
+Nested inline sub-terminals may be defined via a `Terminals` child element.
 
 [width="100%",cols="28%,72%",options="header",]
 |===
 |Attribute |Description
-|name |This required attribute references a terminal type definition by name.
-The name *MUST* match the name of a Terminal entry in the Terminals XML element of the top-level SystemStructureDescription element.
-The member-to-variable binding follows the naming convention `connectorName.memberName`.
+|name |This optional attribute references a global `Terminal` definition by name.
+The name *MUST* match the `name` attribute of a `Terminal` entry in the `Terminals` element of the top-level `SystemStructureDescription` element.
+This attribute *MUST NOT* be present when using an inline definition.
+|===
+
+The following XML child elements are specified for the Terminal element:
+
+[width="100%",cols="28%,72%",options="header",]
+|===
+|Element |Description
+|Connectors |This optional element defines the connector interface in inline terminal definitions.
+Each `Connector` child specifies a connector by `name`, optional `kind`, and optional type (see <<ssc_types>>).
+Must not be present when referencing a global `Terminal` by name.
+|Terminals |This optional element defines nested inline sub-terminal definitions.
+Each `Terminal` child has a `name` (for matching), `matchingRule`, and `Connectors`.
 |===
 
 [#ssc_transformations]

--- a/docs/5___ssd.adoc
+++ b/docs/5___ssd.adoc
@@ -17,7 +17,7 @@ The root element of an SSD file *MUST* be a SystemStructureDescription element, 
 |Attribute |Description
 |version |This required attribute specifies the version of this specification that the system description conforms to.
 Only major and minor version number are included, the patch version number *MUST NOT* be included in this attribute.
-For the current release this *MUST* be either 1.0 or 2.0.
+For the current release this *MUST* be either 1.0, 2.0, or 2.1.
 If it is 1.0 the file *MUST* also conform fully to the 1.0 standard.
 |name |This required attribute provides a name, which can be used for purposes of presenting the system structure to the user, for example when selecting individual variant SSDs from an SSP.
 |===
@@ -32,6 +32,8 @@ The following XML child elements are specified for the SystemStructureDescriptio
 See <<Enumerations>> for its definition.
 |Units |This optional element *MUST* contain definitions for all units referenced in the system description file.
 See <<Units>> for its definition.
+|Terminals |This optional element *MUST* contain definitions for all terminal types referenced in the system description file.
+See <<Terminals>> for its definition.
 |DefaultExperiment |This optional element *MAY* contain information of a default simulation setup that is supplied with the system definition for informational purposes, see description below.
 |===
 
@@ -144,6 +146,10 @@ This can be used for example to allow a connector to function as both an input a
 Connectors of kind `unspecified` are used to define connectors for which the flow of information is either not yet specified, or is determined at runtime, for example for acausal connections of Modelica models.
 Such connectors can be connected to any other connector under the rules of the underlying modeling language.
 
+Connectors of kind `terminal` are used to group member connectors into a structured interface, compatible with FMI 3.0 terminals.
+The name of the connector follows the naming convention `connectorName.memberName` for the member bindings.
+Such a connector *MUST* reference a terminal type definition via a Terminal child element (see <<ssc_types>> for details).
+
 |===
 
 The following XML child elements are specified for the Connector element:
@@ -154,7 +160,7 @@ The following XML child elements are specified for the Connector element:
 |Real / Float64 / Float32 / +
 Integer / Int8 / UInt8 / Int16 / UInt16 / +
 Int32 / UInt32 / Int64 / UInt64 / +
-Boolean / String / Enumeration / Binary / Clock |Exactly one of these elements *CAN* be present to specify the type of the Connector.
+Boolean / String / Enumeration / Binary / Clock / Terminal |Exactly one of these elements *CAN* be present to specify the type of the Connector.
 See <<ssc_types>> for details.
 |Dimension |One or more of these optional elements specify the connector array dimensions, making the connector an array connector.
 See <<ssc_dimensions>> for details.
@@ -838,4 +844,55 @@ Name lookups occur in hierarchical fashion, i.e. the name is first looked up in 
 If that lookup yields no match, the lookup is performed on the enclosing system, etc., until a match is found.
 
 It is an error if no matching signal dictionary is found.
+|===
+
+[#Terminals]
+=== Terminals
+
+image:images/SystemStructureDescription_Terminals.svg[image]
+
+This optional element provides the set of global terminal type definitions for the system structure description.
+Terminal type definitions are referenced by name from connectors of kind `terminal`.
+
+==== Terminal
+
+image:images/SystemStructureDescription_Terminal.svg[image]
+
+This element defines a terminal type, which groups member connectors and optional nested sub-terminals into a structured interface compatible with FMI 3.0 terminals.
+
+The member-to-variable binding follows the naming convention `connectorName.memberName`, where `connectorName` is the name of the connector of kind `terminal` in the system or component, and `memberName` is the name of the member connector defined in this terminal type.
+
+[width="100%",cols="28%,72%",options="header",]
+|===
+|Attribute |Description
+|name |This required attribute gives the terminal type a unique name within the Terminals element.
+Qualified names using reverse domain name notation (e.g. `com.example.MyTerminalType`) are *RECOMMENDED*.
+|matchingRule a|
+This required attribute specifies the rule used to match member connectors when two terminals are connected.
+Compatible with FMI 3.0 terminal matching semantics:
+
+`plug` -- All members must match by `memberName`.
+
+`bus` -- Partial matching by `memberName` is allowed; unmatched members are left unconnected.
+
+`sequence` -- Matching is done by member order; the count of members must match.
+
+`none` -- No automatic matching is performed.
+
+Each terminal's `matchingRule` is evaluated independently.
+|terminalKind |This optional attribute specifies the terminal kind using FMI 3.0 semantics.
+Use reverse domain name notation (e.g. `com.example.MyTerminalType`).
+|===
+
+The following XML child elements are specified for the Terminal element:
+
+[width="100%",cols="23%,77%",options="header",]
+|===
+|Element |Description
+|Connectors |This optional element *MUST* contain the member connectors of this terminal type.
+Member connectors *MUST* use kind `local`.
+See <<Connectors>> for details.
+|Terminals |This optional element *MUST* contain nested sub-terminal type definitions.
+|Annotations |This optional element *MAY* contain annotations.
+See <<Annotations>> for details.
 |===

--- a/docs/5___ssd.adoc
+++ b/docs/5___ssd.adoc
@@ -117,7 +117,7 @@ The following XML attributes are specified for the Connector element:
 |===
 |Attribute |Description
 |name a|
-This attribute gives the connector a name, which *SHALL* be unique within the given model element, and, for components, *MUST* match the name of a relevant variable/port in the underlying component implementation.
+This attribute gives the connector a name, which *SHALL* be unique within the given model element, and, for components, *MUST* match the name of a relevant variable in the underlying component implementation.
 In the case of referenced FMUs this *MUST* match the name of the relevant variable or alias in the referenced FMU.
 
 Note that there is no requirement that connectors have to be present for all variables/ports of an underlying component implementation.
@@ -146,9 +146,9 @@ This can be used for example to allow a connector to function as both an input a
 Connectors of kind `unspecified` are used to define connectors for which the flow of information is either not yet specified, or is determined at runtime, for example for acausal connections of Modelica models.
 Such connectors can be connected to any other connector under the rules of the underlying modeling language.
 
-Connectors of kind `terminal` are used to group member connectors into a structured interface, compatible with FMI 3.0 terminals.
-The name of the connector follows the naming convention `connectorName.memberName` for the member bindings.
-Such a connector *MUST* reference a terminal type definition via a Terminal child element (see <<ssc_types>> for details).
+Connectors of kind `terminal` are used to group named connectors into a structured interface.
+The connector names within the terminal type are used directly as the variable names in the component.
+Such a connector *MUST* carry a `Terminal` child element (see <<ssc_types>> for details), either referencing a global `Terminal` definition by name or providing an inline terminal definition.
 
 |===
 
@@ -632,6 +632,10 @@ For all connections of an element connector of type `Clock` to a system connecto
 |Element |local  |System |local
 |Element |inout |System |output
 |Element |inout |System |local
+|Element |terminal |Element |terminal
+|System |terminal |Element |terminal
+|Element |terminal |System |terminal
+|System |terminal |System |terminal
 |===
 
 The following XML child elements are specified for the Connection element:
@@ -858,24 +862,25 @@ Terminal type definitions are referenced by name from connectors of kind `termin
 
 image:images/SystemStructureDescription_Terminal.svg[image]
 
-This element defines a terminal type, which groups member connectors and optional nested sub-terminals into a structured interface compatible with FMI 3.0 terminals.
+This element defines a terminal type, which groups named connectors and optional nested sub-terminals into a reusable, structured interface.
 
-The member-to-variable binding follows the naming convention `connectorName.memberName`, where `connectorName` is the name of the connector of kind `terminal` in the system or component, and `memberName` is the name of the member connector defined in this terminal type.
+The `name` attribute of each `Connector` within the terminal type is used directly as the variable name in the component at the point of use.
+In particular, separate scalar `Connector` elements for terminal connectors are *not* required.
 
 [width="100%",cols="28%,72%",options="header",]
 |===
 |Attribute |Description
-|name |This required attribute gives the terminal type a unique name within the Terminals element.
+|name |This required attribute gives the terminal type a unique name within the `Terminals` element.
 Qualified names using reverse domain name notation (e.g. `com.example.MyTerminalType`) are *RECOMMENDED*.
 |matchingRule a|
-This required attribute specifies the rule used to match member connectors when two terminals are connected.
+This required attribute specifies the rule used to match connectors when two terminals are connected.
 Compatible with FMI 3.0 terminal matching semantics:
 
-`plug` -- All members must match by `memberName`.
+`plug` -- All connectors must match by `name`.
 
-`bus` -- Partial matching by `memberName` is allowed; unmatched members are left unconnected.
+`bus` -- Partial matching by connector `name` is allowed; unmatched connectors are left unconnected.
 
-`sequence` -- Matching is done by member order; the count of members must match.
+`sequence` -- Matching is done by connector order; the count of connectors must match.
 
 `none` -- No automatic matching is performed.
 
@@ -889,9 +894,11 @@ The following XML child elements are specified for the Terminal element:
 [width="100%",cols="23%,77%",options="header",]
 |===
 |Element |Description
-|Connectors |This optional element *MUST* contain the member connectors of this terminal type.
-Member connectors *MUST* use kind `local`.
-See <<Connectors>> for details.
+|Connectors |This optional element defines the connector interface of this terminal type.
+Each `Connector` child specifies a connector by `name`, optional `kind`, and optional type (see <<ssc_types>>).
+The `name` attribute is used directly as the variable name in the component at the point of use; no separate name mapping is required.
+`kind` may be omitted; the same terminal type is used on both ends of a connection, with directions being complementary.
+`Connector` elements of kind `terminal` *MUST NOT* appear here; use the `Terminals` child for nested sub-terminal types.
 |Terminals |This optional element *MUST* contain nested sub-terminal type definitions.
 |Annotations |This optional element *MAY* contain annotations.
 See <<Annotations>> for details.

--- a/schema/SystemStructureCommon.xsd
+++ b/schema/SystemStructureCommon.xsd
@@ -7,7 +7,7 @@
             This is the normative XML Schema 1.0 schema for the MAP SSP
             SystemStructure 2.0 common content across formats.
 
-            Version: 2.1.0
+            Version: 2.1.0-alpha
 
             Copyright 2016 -- 2026 Modelica Association Project "SSP"
 

--- a/schema/SystemStructureCommon.xsd
+++ b/schema/SystemStructureCommon.xsd
@@ -7,7 +7,7 @@
             This is the normative XML Schema 1.0 schema for the MAP SSP
             SystemStructure 2.0 common content across formats.
 
-            Version: 2.0.1
+            Version: 2.1.0
 
             Copyright 2016 -- 2026 Modelica Association Project "SSP"
 
@@ -612,6 +612,25 @@
                   <xs:attribute name="intervalCounter" type="xs:unsignedLong" use="optional"/>
                   <xs:attribute name="shiftCounter" type="xs:unsignedLong" default="0"/>
                   <xs:attribute name="priority" type="xs:unsignedInt" use="optional"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Terminal">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        References a global terminal type definition by name.
+                        The member-to-variable binding follows the naming
+                        convention connectorName.memberName.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                References a Terminal defined in the Terminals
+                                section of the enclosing SystemStructureDescription.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
                 </xs:complexType>
             </xs:element>
         </xs:choice>

--- a/schema/SystemStructureCommon.xsd
+++ b/schema/SystemStructureCommon.xsd
@@ -446,12 +446,13 @@
         <xs:attributeGroup ref="ssc:ABaseElement"/>
     </xs:complexType>
 
-    <xs:group name="GTypeChoice">
+    <xs:group name="GValueTypeChoice">
         <xs:choice>
             <xs:annotation>
                 <xs:documentation xml:lang="en">
-                    This element gives the type of a connector or signal dictionary entry
-                    (called entity below).
+                    The value-carrying type choices for a connector or signal dictionary
+                    entry: all types except Terminal. Used directly by TTerminalConnectors
+                    (where Terminal is not permitted) and composed into GTypeChoice.
                 </xs:documentation>
             </xs:annotation>
             <xs:element name="Real">
@@ -614,27 +615,321 @@
                   <xs:attribute name="priority" type="xs:unsignedInt" use="optional"/>
                 </xs:complexType>
             </xs:element>
-            <xs:element name="Terminal">
+            <xs:element name="Terminal" type="ssc:TTerminal">
                 <xs:annotation>
                     <xs:documentation xml:lang="en">
-                        References a global terminal type definition by name.
-                        The member-to-variable binding follows the naming
-                        convention connectorName.memberName.
+                        Specifies the terminal type for a connector of kind "terminal".
+                        Two usage patterns are supported (see TTerminal and TTerminalType):
+                        1. Global type reference: provide only the name attribute, which
+                           references a TerminalType in the Terminals section of the SSD.
+                           The connector names are used directly as the variable names.
+                        2. Inline definition: omit name and provide matchingRule along with
+                           a Connectors child. Each Connector's name serves as the
+                           terminal-internal connector name and the variable name; the
+                           optional variableName attribute overrides the variable name.
                     </xs:documentation>
                 </xs:annotation>
-                <xs:complexType>
-                    <xs:attribute name="name" type="xs:string" use="required">
-                        <xs:annotation>
-                            <xs:documentation xml:lang="en">
-                                References a Terminal defined in the Terminals
-                                section of the enclosing SystemStructureDescription.
-                            </xs:documentation>
-                        </xs:annotation>
-                    </xs:attribute>
-                </xs:complexType>
             </xs:element>
         </xs:choice>
     </xs:group>
+
+    <xs:group name="GTypeChoice">
+        <xs:choice>
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This element gives the type of a connector or signal dictionary entry
+                    (called entity below).
+                </xs:documentation>
+            </xs:annotation>
+            <xs:group ref="ssc:GValueTypeChoice"/>
+            <xs:element name="Terminal" type="ssc:TTerminal">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        Specifies the terminal type for a connector of kind "terminal".
+                        Two usage patterns are supported (see TTerminal and TTerminalType):
+                        1. Global type reference: provide only the name attribute, which
+                           references a TerminalType in the Terminals section of the SSD.
+                           The connector names are used directly as the variable names.
+                        2. Inline definition: omit name and provide matchingRule along with
+                           a Connectors child. Each Connector's name serves as the
+                           terminal-internal connector name and the variable name; the
+                           optional variableName attribute overrides the variable name.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:choice>
+    </xs:group>
+
+    <xs:complexType name="TTerminalConnectors">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                The set of connectors within a terminal type definition or inline terminal definition.
+
+                Each connector is identified by its name, which serves as the connector
+                name within the terminal interface and, unless variableName is specified,
+                also as the variable/port name in the component at the point of use.
+                The optional variableName attribute overrides the variable/port name bound
+                in the component, decoupling the terminal interface name (used for matching)
+                from the underlying component variable name.
+
+                Connectors within a terminal definition must not use kind "terminal"; nested
+                sub-terminals are expressed via the Terminals child element of the enclosing
+                TTerminalType or TTerminal.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="Connector" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:group ref="ssc:GValueTypeChoice" minOccurs="0"/>
+                        <xs:group ref="ssc:GDimensions"/>
+                        <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
+                    </xs:sequence>
+                    <xs:attributeGroup ref="ssc:ABaseElement"/>
+                    <xs:attribute name="name" type="xs:string" use="required">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                The name of this connector within the terminal interface.
+                                Used for terminal connector matching. Unless variableName
+                                is also specified, this name is also used as the variable/port
+                                name in the component at the point of use.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="variableName" type="xs:string" use="optional">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                Optional override for the variable/port name in the component
+                                at the point of use. When present, this name is used to bind
+                                to the variable/port in the component instead of the name
+                                attribute. This allows the terminal connector name (used for
+                                terminal matching) to differ from the underlying component
+                                variable name, enabling adaptation of components whose variable
+                                names differ from the terminal type connector names.
+                                When absent, the name attribute is used as the variable/port name.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="kind" use="optional">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                The kind (causality/variability) of this terminal connector.
+                                May be omitted in global Terminal type definitions, since the
+                                same type is used on both ends of a connection with complementary
+                                directions. Should be specified in inline terminal definitions
+                                where direction is known.
+                                The value "terminal" must not be used here; nested sub-terminals
+                                are expressed via the Terminals child element of the enclosing
+                                Terminal type or inline Terminal definition.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="input"/>
+                                <xs:enumeration value="output"/>
+                                <xs:enumeration value="parameter"/>
+                                <xs:enumeration value="calculatedParameter"/>
+                                <xs:enumeration value="structuralParameter"/>
+                                <xs:enumeration value="constant"/>
+                                <xs:enumeration value="local"/>
+                                <xs:enumeration value="inout"/>
+                                <xs:enumeration value="unspecified"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="TTerminalType">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                A named terminal type definition. Defines the interface of a reusable
+                terminal type, registered in the Terminals section of an SSD.
+                Components and sub-systems reference this type by name using
+                ssc:Terminal name="..." on a connector of kind="terminal".
+                The connector names defined here are used directly as the variable
+                names in the component; no separate name mapping is required.
+                Required attributes: name (unique within the Terminals collection),
+                matchingRule.
+                The Connectors child defines the terminal's connector interface.
+                The Terminals child defines nested sub-terminal types.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="Connectors" minOccurs="0" type="ssc:TTerminalConnectors">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        Defines the connector interface of this terminal type. Each Connector
+                        child specifies a connector by name, kind, and optional type. The
+                        connector name is used directly as the variable name in the
+                        component at the point of use; no separate name mapping is required.
+                        Connectors of kind "terminal" must not appear here; use the Terminals
+                        child for nested sub-terminal types.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="Terminals" minOccurs="0" type="ssc:TTerminalTypes">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        Nested sub-terminal type definitions that form part of this
+                        terminal type's interface. Each TerminalType child defines a
+                        named sub-terminal.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
+        </xs:sequence>
+        <xs:attributeGroup ref="ssc:ABaseElement"/>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    The unique name of this terminal type. Qualified names using reverse
+                    domain name notation (e.g. "com.example.ControlInterface") are
+                    recommended. Must be unique within the enclosing Terminals collection.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="matchingRule" type="xs:normalizedString" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    Matching rule for connecting terminals (FMI 3.0 semantics).
+                    This is an open string (xs:normalizedString) following FMI 3.0,
+                    allowing tool-specific and domain-specific rules in addition to
+                    the standard values:
+                    - plug: All connectors must match by name.
+                    - bus: Partial matching by connector name allowed.
+                    - sequence: Matching by connector order; count must match.
+                    - none: No automatic matching.
+                    Each terminal level is evaluated independently.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="terminalKind" type="xs:normalizedString" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    Optional terminal kind (FMI 3.0 semantics). Use reverse domain
+                    name notation (e.g. "com.example.MyTerminalType").
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="TTerminalTypes">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                A collection of Terminal elements defining reusable terminal types. Used either
+                at the top level of an SSD (global terminal type registry) or as the Terminals
+                child of a TTerminalType (for nested sub-terminal type definitions). Each
+                Terminal element's name must be unique within the collection.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="Terminal" minOccurs="1" maxOccurs="unbounded" type="ssc:TTerminalType"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="TTerminal">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Represents a terminal at the point of use on a connector of kind="terminal".
+                Two usage patterns are supported:
+
+                1. Global type reference:
+                   Provide only the name attribute, referencing a TerminalType in the
+                   Terminals section of the SSD. The connector names defined in the
+                   TerminalType are used directly as the variable names in the component.
+
+                2. Inline definition:
+                   Omit name and provide matchingRule along with a Connectors child.
+                   Each Connector's name serves as both the terminal-internal connector
+                   name and the variable name in the component. The optional variableName
+                   attribute on a Connector overrides the variable name, allowing
+                   adaptation of components whose variable names differ from the connector
+                   names. Nested inline sub-terminals may be defined via a Terminals child.
+
+                Note: XSD 1.0 cannot enforce context constraints; implementations must
+                validate these semantic constraints.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="Connectors" minOccurs="0" type="ssc:TTerminalConnectors">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        Defines the connector interface in inline terminal definitions.
+                        Each Connector's name serves both as the terminal-internal connector
+                        name and as the variable name in the component; the optional
+                        variableName attribute overrides the variable name.
+                        Must not be present when referencing a global TerminalType by name.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="Terminals" minOccurs="0" type="ssc:TTerminals">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        Nested inline sub-terminal definitions. Each Terminal child has
+                        a name (for matching), matchingRule, and Connectors.
+                        Used only in inline terminal definitions; not applicable in global
+                        type references (sub-terminal definitions are part of the
+                        referenced TerminalType).
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
+        </xs:sequence>
+        <xs:attributeGroup ref="ssc:ABaseElement"/>
+        <xs:attribute name="name" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    In global type references: required; references a Terminal defined
+                    in the Terminals section of the enclosing SSD. Qualified type names
+                    (e.g. "com.example.ControlInterface") are recommended.
+                    In nested inline sub-terminal definitions: required; identifies the
+                    sub-terminal by name for matching purposes.
+                    In outermost inline terminal definitions: must not be present.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="matchingRule" type="xs:normalizedString" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    Matching rule for connecting terminals (FMI 3.0 semantics).
+                    This is an open string (xs:normalizedString) following FMI 3.0,
+                    allowing tool-specific and domain-specific rules in addition to
+                    the standard values:
+                    - plug: All connectors must match by name.
+                    - bus: Partial matching by connector name allowed.
+                    - sequence: Matching by connector order; count must match.
+                    - none: No automatic matching.
+                    Required in inline terminal definitions (outermost and nested inline
+                    sub-terminals). Not present in global type references, where the
+                    matchingRule is taken from the referenced TerminalType.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="terminalKind" type="xs:normalizedString" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    Optional terminal kind (FMI 3.0 semantics). Use reverse domain
+                    name notation (e.g. "com.example.MyTerminalType").
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="TTerminals">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                A collection of Terminal elements at the point of use. Used as the
+                Terminals child of TTerminal for nested inline sub-terminal definitions.
+                Each Terminal child has a name (for matching), matchingRule, and Connectors.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="Terminal" minOccurs="1" maxOccurs="unbounded" type="ssc:TTerminal"/>
+        </xs:sequence>
+    </xs:complexType>
 
     <xs:group name="GTransformationChoice">
         <xs:annotation>

--- a/schema/SystemStructureDescription.xsd
+++ b/schema/SystemStructureDescription.xsd
@@ -8,7 +8,7 @@
             This is the normative XML Schema 1.0 schema for the MAP SSP
             SystemStructureDescription 2.1 format.
 
-            Version: 2.1.0
+            Version: 2.1.0-alpha
 
             Copyright 2016 -- 2026 Modelica Association Project "SSP"
 

--- a/schema/SystemStructureDescription.xsd
+++ b/schema/SystemStructureDescription.xsd
@@ -50,7 +50,7 @@
                 <xs:element name="System" type="ssd:TSystem"/>
                 <xs:element name="Enumerations" minOccurs="0" type="ssc:TEnumerations"/>
                 <xs:element name="Units" minOccurs="0" type="ssc:TUnits"/>
-                <xs:element name="Terminals" minOccurs="0" type="ssd:TTerminals"/>
+                <xs:element name="Terminals" minOccurs="0" type="ssc:TTerminalTypes"/>
                 <xs:element name="DefaultExperiment" minOccurs="0" type="ssd:TDefaultExperiment"/>
                 <xs:group ref="ssc:GMetaData"/>
                 <xs:group ref="ssc:GSignature"/>
@@ -97,7 +97,7 @@
                         The set of connectors of this element, which represent
                         the interface of the element to the outside world.
 
-                        For components the set of connectors must match variable/ports
+                        For components the set of connectors must match variables
                         of the underlying component implementation, e.g. the referenced
                         FMU, by name.
 
@@ -728,7 +728,7 @@
                                 This attribute gives the connector a name, which
                                 shall be unique within the component or system and,
                                 for components, must match the name of a relevant
-                                variable/port in the underlying component implementation,
+                                variable in the underlying component implementation,
                                 e.g. the referenced FMU.
 
                                 Note that there is no requirement that connectors must
@@ -1054,82 +1054,6 @@
                 </xs:complexType>
             </xs:element>
         </xs:sequence>
-    </xs:complexType>
-
-    <xs:complexType name="TTerminals">
-        <xs:annotation>
-            <xs:documentation xml:lang="en">
-                A set of terminal type definitions, referenced by name from
-                connectors of kind "terminal".
-            </xs:documentation>
-        </xs:annotation>
-        <xs:sequence>
-            <xs:element name="Terminal" minOccurs="1" maxOccurs="unbounded" type="ssd:TTerminal"/>
-        </xs:sequence>
-    </xs:complexType>
-
-    <xs:complexType name="TTerminal">
-        <xs:annotation>
-            <xs:documentation xml:lang="en">
-                Defines a terminal type with member connectors (kind="local"),
-                optional nested sub-terminals, and a matching rule.
-                Compatible with FMI 3.0 terminals.
-            </xs:documentation>
-        </xs:annotation>
-        <xs:sequence>
-            <xs:element name="Connectors" minOccurs="0" type="ssd:TConnectors">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
-                        The member connectors of this terminal, using kind="local".
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element name="Terminals" minOccurs="0" type="ssd:TTerminals">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
-                        Nested sub-terminals.
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
-        </xs:sequence>
-        <xs:attributeGroup ref="ssc:ABaseElement"/>
-        <xs:attribute name="name" type="xs:string" use="required">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
-                    Unique name of the terminal type. Qualified names
-                    (e.g. reverse domain name notation) are recommended.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="matchingRule" use="required">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
-                    Matching rule for connecting terminals (FMI 3.0 semantics):
-                    - plug: All members must match by memberName.
-                    - bus: Partial matching by memberName allowed.
-                    - sequence: Matching by member order; count must match.
-                    - none: No automatic matching.
-                    Each terminal's matchingRule is evaluated independently.
-                </xs:documentation>
-            </xs:annotation>
-            <xs:simpleType>
-                <xs:restriction base="xs:normalizedString">
-                    <xs:enumeration value="plug"/>
-                    <xs:enumeration value="bus"/>
-                    <xs:enumeration value="sequence"/>
-                    <xs:enumeration value="none"/>
-                </xs:restriction>
-            </xs:simpleType>
-        </xs:attribute>
-        <xs:attribute name="terminalKind" type="xs:normalizedString" use="optional">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
-                    Optional terminal kind (FMI 3.0 semantics). Use reverse domain
-                    name notation (e.g. "com.example.MyTerminalType").
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="TDefaultExperiment">

--- a/schema/SystemStructureDescription.xsd
+++ b/schema/SystemStructureDescription.xsd
@@ -6,9 +6,9 @@
     <xs:annotation>
         <xs:documentation xml:lang="en">
             This is the normative XML Schema 1.0 schema for the MAP SSP
-            SystemStructureDescription 2.0 format.
+            SystemStructureDescription 2.1 format.
 
-            Version: 2.0.1
+            Version: 2.1.0
 
             Copyright 2016 -- 2026 Modelica Association Project "SSP"
 
@@ -50,6 +50,7 @@
                 <xs:element name="System" type="ssd:TSystem"/>
                 <xs:element name="Enumerations" minOccurs="0" type="ssc:TEnumerations"/>
                 <xs:element name="Units" minOccurs="0" type="ssc:TUnits"/>
+                <xs:element name="Terminals" minOccurs="0" type="ssd:TTerminals"/>
                 <xs:element name="DefaultExperiment" minOccurs="0" type="ssd:TDefaultExperiment"/>
                 <xs:group ref="ssc:GMetaData"/>
                 <xs:group ref="ssc:GSignature"/>
@@ -65,6 +66,7 @@
                     <xs:restriction base="xs:normalizedString">
                         <xs:pattern value="1[.]0"/>
                         <xs:pattern value="2[.]0"/>
+                        <xs:pattern value="2[.]1"/>
                     </xs:restriction>
                 </xs:simpleType>
             </xs:attribute>
@@ -795,6 +797,7 @@
                                 <xs:enumeration value="local"/>
                                 <xs:enumeration value="inout"/>
                                 <xs:enumeration value="unspecified"/>
+                                <xs:enumeration value="terminal"/>
                             </xs:restriction>
                         </xs:simpleType>
                     </xs:attribute>
@@ -1051,6 +1054,82 @@
                 </xs:complexType>
             </xs:element>
         </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="TTerminals">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                A set of terminal type definitions, referenced by name from
+                connectors of kind "terminal".
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="Terminal" minOccurs="1" maxOccurs="unbounded" type="ssd:TTerminal"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="TTerminal">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Defines a terminal type with member connectors (kind="local"),
+                optional nested sub-terminals, and a matching rule.
+                Compatible with FMI 3.0 terminals.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="Connectors" minOccurs="0" type="ssd:TConnectors">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        The member connectors of this terminal, using kind="local".
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="Terminals" minOccurs="0" type="ssd:TTerminals">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        Nested sub-terminals.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
+        </xs:sequence>
+        <xs:attributeGroup ref="ssc:ABaseElement"/>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    Unique name of the terminal type. Qualified names
+                    (e.g. reverse domain name notation) are recommended.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="matchingRule" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    Matching rule for connecting terminals (FMI 3.0 semantics):
+                    - plug: All members must match by memberName.
+                    - bus: Partial matching by memberName allowed.
+                    - sequence: Matching by member order; count must match.
+                    - none: No automatic matching.
+                    Each terminal's matchingRule is evaluated independently.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:normalizedString">
+                    <xs:enumeration value="plug"/>
+                    <xs:enumeration value="bus"/>
+                    <xs:enumeration value="sequence"/>
+                    <xs:enumeration value="none"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="terminalKind" type="xs:normalizedString" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    Optional terminal kind (FMI 3.0 semantics). Use reverse domain
+                    name notation (e.g. "com.example.MyTerminalType").
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="TDefaultExperiment">

--- a/schema/SystemStructureDescription11.xsd
+++ b/schema/SystemStructureDescription11.xsd
@@ -14,7 +14,7 @@
             as a non-normative alternative to the XML Schema 1.0 schema
             to support simpler cross-namespace validation of SSD files.
 
-            Version: 2.1.0
+            Version: 2.1.0-alpha
 
             Copyright 2016 -- 2026 Modelica Association Project "SSP"
 

--- a/schema/SystemStructureDescription11.xsd
+++ b/schema/SystemStructureDescription11.xsd
@@ -59,7 +59,7 @@
                 <xs:element name="System" type="ssd:TSystem"/>
                 <xs:element name="Enumerations" minOccurs="0" type="ssc:TEnumerations"/>
                 <xs:element name="Units" minOccurs="0" type="ssc:TUnits"/>
-                <xs:element name="Terminals" minOccurs="0" type="ssd:TTerminals"/>
+                <xs:element name="Terminals" minOccurs="0" type="ssc:TTerminalTypes"/>
                 <xs:element name="DefaultExperiment" minOccurs="0" type="ssd:TDefaultExperiment"/>
                 <xs:group ref="ssc:GMetaData"/>
                 <xs:group ref="ssc:GSignature"/>
@@ -106,7 +106,7 @@
                         The set of connectors of this element, which represent
                         the interface of the element to the outside world.
 
-                        For components the set of connectors must match variable/ports
+                        For components the set of connectors must match variables
                         of the underlying component implementation, e.g. the referenced
                         FMU, by name.
 
@@ -712,7 +712,7 @@
                                 This attribute gives the connector a name, which
                                 shall be unique within the component or system and,
                                 for components, must match the name of a relevant
-                                variable/port in the underlying component implementation,
+                                variable in the underlying component implementation,
                                 e.g. the referenced FMU.
 
                                 Note that there is no requirement that connectors must
@@ -1001,82 +1001,6 @@
                 </xs:complexType>
             </xs:element>
         </xs:sequence>
-    </xs:complexType>
-
-    <xs:complexType name="TTerminals">
-        <xs:annotation>
-            <xs:documentation xml:lang="en">
-                A set of terminal type definitions, referenced by name from
-                connectors of kind "terminal".
-            </xs:documentation>
-        </xs:annotation>
-        <xs:sequence>
-            <xs:element name="Terminal" minOccurs="1" maxOccurs="unbounded" type="ssd:TTerminal"/>
-        </xs:sequence>
-    </xs:complexType>
-
-    <xs:complexType name="TTerminal">
-        <xs:annotation>
-            <xs:documentation xml:lang="en">
-                Defines a terminal type with member connectors (kind="local"),
-                optional nested sub-terminals, and a matching rule.
-                Compatible with FMI 3.0 terminals.
-            </xs:documentation>
-        </xs:annotation>
-        <xs:sequence>
-            <xs:element name="Connectors" minOccurs="0" type="ssd:TConnectors">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
-                        The member connectors of this terminal, using kind="local".
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element name="Terminals" minOccurs="0" type="ssd:TTerminals">
-                <xs:annotation>
-                    <xs:documentation xml:lang="en">
-                        Nested sub-terminals.
-                    </xs:documentation>
-                </xs:annotation>
-            </xs:element>
-            <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
-        </xs:sequence>
-        <xs:attributeGroup ref="ssc:ABaseElement"/>
-        <xs:attribute name="name" type="xs:string" use="required">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
-                    Unique name of the terminal type. Qualified names
-                    (e.g. reverse domain name notation) are recommended.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="matchingRule" use="required">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
-                    Matching rule for connecting terminals (FMI 3.0 semantics):
-                    - plug: All members must match by memberName.
-                    - bus: Partial matching by memberName allowed.
-                    - sequence: Matching by member order; count must match.
-                    - none: No automatic matching.
-                    Each terminal's matchingRule is evaluated independently.
-                </xs:documentation>
-            </xs:annotation>
-            <xs:simpleType>
-                <xs:restriction base="xs:normalizedString">
-                    <xs:enumeration value="plug"/>
-                    <xs:enumeration value="bus"/>
-                    <xs:enumeration value="sequence"/>
-                    <xs:enumeration value="none"/>
-                </xs:restriction>
-            </xs:simpleType>
-        </xs:attribute>
-        <xs:attribute name="terminalKind" type="xs:normalizedString" use="optional">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
-                    Optional terminal kind (FMI 3.0 semantics). Use reverse domain
-                    name notation (e.g. "com.example.MyTerminalType").
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="TDefaultExperiment">

--- a/schema/SystemStructureDescription11.xsd
+++ b/schema/SystemStructureDescription11.xsd
@@ -10,11 +10,11 @@
     <xs:annotation>
         <xs:documentation xml:lang="en">
             This is the XML Schema 1.1 schema for the MAP SSP
-            SystemStructureDescription 2.0 format.  It is provided
+            SystemStructureDescription 2.1 format.  It is provided
             as a non-normative alternative to the XML Schema 1.0 schema
             to support simpler cross-namespace validation of SSD files.
 
-            Version: 2.0.1
+            Version: 2.1.0
 
             Copyright 2016 -- 2026 Modelica Association Project "SSP"
 
@@ -59,6 +59,7 @@
                 <xs:element name="System" type="ssd:TSystem"/>
                 <xs:element name="Enumerations" minOccurs="0" type="ssc:TEnumerations"/>
                 <xs:element name="Units" minOccurs="0" type="ssc:TUnits"/>
+                <xs:element name="Terminals" minOccurs="0" type="ssd:TTerminals"/>
                 <xs:element name="DefaultExperiment" minOccurs="0" type="ssd:TDefaultExperiment"/>
                 <xs:group ref="ssc:GMetaData"/>
                 <xs:group ref="ssc:GSignature"/>
@@ -74,6 +75,7 @@
                     <xs:restriction base="xs:normalizedString">
                         <xs:pattern value="1[.]0"/>
                         <xs:pattern value="2[.]0"/>
+                        <xs:pattern value="2[.]1"/>
                     </xs:restriction>
                 </xs:simpleType>
             </xs:attribute>
@@ -779,6 +781,7 @@
                                 <xs:enumeration value="local"/>
                                 <xs:enumeration value="inout"/>
                                 <xs:enumeration value="unspecified"/>
+                                <xs:enumeration value="terminal"/>
                             </xs:restriction>
                         </xs:simpleType>
                     </xs:attribute>
@@ -998,6 +1001,82 @@
                 </xs:complexType>
             </xs:element>
         </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="TTerminals">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                A set of terminal type definitions, referenced by name from
+                connectors of kind "terminal".
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="Terminal" minOccurs="1" maxOccurs="unbounded" type="ssd:TTerminal"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="TTerminal">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                Defines a terminal type with member connectors (kind="local"),
+                optional nested sub-terminals, and a matching rule.
+                Compatible with FMI 3.0 terminals.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="Connectors" minOccurs="0" type="ssd:TConnectors">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        The member connectors of this terminal, using kind="local".
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="Terminals" minOccurs="0" type="ssd:TTerminals">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        Nested sub-terminals.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
+        </xs:sequence>
+        <xs:attributeGroup ref="ssc:ABaseElement"/>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    Unique name of the terminal type. Qualified names
+                    (e.g. reverse domain name notation) are recommended.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="matchingRule" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    Matching rule for connecting terminals (FMI 3.0 semantics):
+                    - plug: All members must match by memberName.
+                    - bus: Partial matching by memberName allowed.
+                    - sequence: Matching by member order; count must match.
+                    - none: No automatic matching.
+                    Each terminal's matchingRule is evaluated independently.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:normalizedString">
+                    <xs:enumeration value="plug"/>
+                    <xs:enumeration value="bus"/>
+                    <xs:enumeration value="sequence"/>
+                    <xs:enumeration value="none"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="terminalKind" type="xs:normalizedString" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    Optional terminal kind (FMI 3.0 semantics). Use reverse domain
+                    name notation (e.g. "com.example.MyTerminalType").
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="TDefaultExperiment">

--- a/schema/SystemStructureParameterMapping.xsd
+++ b/schema/SystemStructureParameterMapping.xsd
@@ -8,7 +8,7 @@
             This is the normative XML Schema 1.0 schema for the MAP SSP
             SystemStructureParameterMapping 2.1 format.
 
-            Version: 2.1.0
+            Version: 2.1.0-alpha
 
             Copyright 2016 -- 2026 Modelica Association Project "SSP"
 

--- a/schema/SystemStructureParameterMapping.xsd
+++ b/schema/SystemStructureParameterMapping.xsd
@@ -6,9 +6,9 @@
     <xs:annotation>
         <xs:documentation xml:lang="en">
             This is the normative XML Schema 1.0 schema for the MAP SSP
-            SystemStructureParameterMapping 2.0 format.
+            SystemStructureParameterMapping 2.1 format.
 
-            Version: 2.0.1
+            Version: 2.1.0
 
             Copyright 2016 -- 2026 Modelica Association Project "SSP"
 

--- a/schema/SystemStructureParameterValues.xsd
+++ b/schema/SystemStructureParameterValues.xsd
@@ -8,7 +8,7 @@
             This is the normative XML Schema 1.0 schema for the MAP SSP
             SystemStructureParameterValues 2.1 format.
 
-            Version: 2.1.0
+            Version: 2.1.0-alpha
 
             Copyright 2016 -- 2026 Modelica Association Project "SSP"
 

--- a/schema/SystemStructureParameterValues.xsd
+++ b/schema/SystemStructureParameterValues.xsd
@@ -6,9 +6,9 @@
     <xs:annotation>
         <xs:documentation xml:lang="en">
             This is the normative XML Schema 1.0 schema for the MAP SSP
-            SystemStructureParameterValues 2.0 format.
+            SystemStructureParameterValues 2.1 format.
 
-            Version: 2.0.1
+            Version: 2.1.0
 
             Copyright 2016 -- 2026 Modelica Association Project "SSP"
 

--- a/schema/SystemStructureSignalDictionary.xsd
+++ b/schema/SystemStructureSignalDictionary.xsd
@@ -8,7 +8,7 @@
             This is the normative XML Schema 1.0 schema for the MAP SSP
             SystemStructureSignalDictionary 2.1 format.
 
-            Version: 2.1.0
+            Version: 2.1.0-alpha
 
             Copyright 2016 -- 2026 Modelica Association Project "SSP"
 

--- a/schema/SystemStructureSignalDictionary.xsd
+++ b/schema/SystemStructureSignalDictionary.xsd
@@ -6,9 +6,9 @@
     <xs:annotation>
         <xs:documentation xml:lang="en">
             This is the normative XML Schema 1.0 schema for the MAP SSP
-            SystemStructureSignalDictionary 2.0 format.
+            SystemStructureSignalDictionary 2.1 format.
 
-            Version: 2.0.1
+            Version: 2.1.0
 
             Copyright 2016 -- 2026 Modelica Association Project "SSP"
 


### PR DESCRIPTION
This draft adds support for FMI 3.0-style terminals to SSP 2.1. The draft closely follows the proposals from @DagBruck in #83.

Related to #59, #56, #84

Terminals are defined globally at the SSD root level (similar to `Units` and `Enumerations`), giving them a name that components can reference by. A terminal connector is declared with `kind="terminal"` and carries a `<ssc:Terminal name="..."/>` child pointing at the global terminal defintiion.

Member variables are bound by naming convention: a connector named `portName.memberName` is automatically associated with the terminal connector `portName`. This avoids any new connection syntax and keeps full backward compatibilty with SSP 2.0 systems.

Terminals carry a `matchingRule` attribute (`plug`, `bus`, `sequence`, `none`) taken from the FMI 3.0 terminal semantics, which tools can use for connection validation. Fan-out of terminal connections follows the same rules as scalar connections — an input member may only be written by one source.

```
┌──────────────────────────────────────────────────────────────────┐
│ System                                                           │
│  ┌───────────────┐                        ┌────────────────┐     │
│  │ Controller    │                        │ Plant          │     │
│  │               │                        │                │     │
│  │  controlPort <╪═══╦════════════════════╪> controlPort   │     │
│  │               │   ║                    │                │     │
│  │ externalSet- <┼───║────────────────────┼  measuredPos.  │     │
│  │  point        │   ║                    │                │     │
│  └───────────────┘   ║                    └────────────────┘     │
│                      ║                                           │
│                      ║     ┌──────────────────────────────────┐  │
│                      ║     │ Monitor                          │  │
│                      ║     │                 ┌──────────────┐ │  │
│                      ║     │                 │ Logger       │ │  │
│                      ╚═════╪> monitorPort    │              │ │  │
│                            │   .position ────┼> logPosition │ │  │
│                            │   .velocity ────┼> logVelocity │ │  │
│                            │                 └──────────────┘ │  │
│                            └──────────────────────────────────┘  │
└──────────────────────────────────────────────────────────────────┘

═══  Terminal connection (single connection, bidirectional signals)
───  Scalar connection
```


```xml
<?xml version="1.0" encoding="UTF-8"?>
<ssd:SystemStructureDescription
    xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
    xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
    name="TerminalExample" version="2.1">

    <ssd:System name="System">
        <ssd:Elements>
            <!-- Controller: outputs position/velocity commands, receives force feedback -->
            <ssd:Component name="Controller" source="resources/Controller.fmu">
                <ssd:Connectors>
                    <ssd:Connector kind="terminal" name="controlPort">
                        <ssc:Terminal name="com.example.ControlSignals"/>
                        <ssd:ConnectorGeometry x="1" y="0.5"/>
                    </ssd:Connector>
                    <ssd:Connector kind="output" name="controlPort.position">
                        <ssc:Real unit="m"/>
                    </ssd:Connector>
                    <ssd:Connector kind="output" name="controlPort.velocity">
                        <ssc:Real unit="m/s"/>
                    </ssd:Connector>
                    <ssd:Connector kind="input" name="controlPort.force">
                        <ssc:Real unit="N"/>
                    </ssd:Connector>
                    <ssd:Connector kind="input" name="externalSetpoint">
                        <ssc:Real/>
                    </ssd:Connector>
                </ssd:Connectors>
                <ssd:ElementGeometry x1="-80" y1="-20" x2="-40" y2="20"/>
            </ssd:Component>

            <!-- Plant: receives position/velocity commands, outputs force measurement -->
            <ssd:Component name="Plant" source="resources/Plant.fmu">
                <ssd:Connectors>
                    <ssd:Connector kind="terminal" name="controlPort">
                        <ssc:Terminal name="com.example.ControlSignals"/>
                        <ssd:ConnectorGeometry x="0" y="0.5"/>
                    </ssd:Connector>
                    <ssd:Connector kind="input" name="controlPort.position">
                        <ssc:Real unit="m"/>
                    </ssd:Connector>
                    <ssd:Connector kind="input" name="controlPort.velocity">
                        <ssc:Real unit="m/s"/>
                    </ssd:Connector>
                    <ssd:Connector kind="output" name="controlPort.force">
                        <ssc:Real unit="N"/>
                    </ssd:Connector>
                    <ssd:Connector kind="output" name="measuredPosition">
                        <ssc:Real unit="m"/>
                    </ssd:Connector>
                </ssd:Connectors>
                <ssd:ElementGeometry x1="40" y1="-20" x2="80" y2="20"/>
            </ssd:Component>

            <!-- Monitor subsystem: terminal on its interface, scalar access inside -->
            <ssd:System name="Monitor">
                <ssd:Connectors>
                    <ssd:Connector kind="terminal" name="monitorPort">
                        <ssc:Terminal name="com.example.ControlSignals"/>
                        <ssd:ConnectorGeometry x="0" y="0.5"/>
                    </ssd:Connector>
                    <ssd:Connector kind="input" name="monitorPort.position">
                        <ssc:Real unit="m"/>
                    </ssd:Connector>
                    <ssd:Connector kind="input" name="monitorPort.velocity">
                        <ssc:Real unit="m/s"/>
                    </ssd:Connector>
                </ssd:Connectors>
                <ssd:ElementGeometry x1="40" y1="-60" x2="80" y2="-30"/>
                <ssd:Elements>
                    <ssd:Component name="Logger" source="resources/Logger.fmu">
                        <ssd:Connectors>
                            <ssd:Connector kind="input" name="logPosition">
                                <ssc:Real unit="m"/>
                            </ssd:Connector>
                            <ssd:Connector kind="input" name="logVelocity">
                                <ssc:Real unit="m/s"/>
                            </ssd:Connector>
                        </ssd:Connectors>
                    </ssd:Component>
                </ssd:Elements>
                <ssd:Connections>
                    <!-- Inside the subsystem: connect individual terminal members -->
                    <ssd:Connection startConnector="monitorPort.position"
                                    endElement="Logger" endConnector="logPosition"/>
                    <ssd:Connection startConnector="monitorPort.velocity"
                                    endElement="Logger" endConnector="logVelocity"/>
                </ssd:Connections>
            </ssd:System>
        </ssd:Elements>

        <ssd:Connections>
            <!-- Terminal connection: carries position+velocity OUT and force IN -->
            <ssd:Connection startElement="Controller" startConnector="controlPort"
                            endElement="Plant" endConnector="controlPort"/>

            <!-- Same terminal to Monitor -->
            <ssd:Connection startElement="Controller" startConnector="controlPort"
                            endElement="Monitor" endConnector="monitorPort"/>

            <!-- Scalar connection (non-terminal) -->
            <ssd:Connection startElement="Plant" startConnector="measuredPosition"
                            endElement="Controller" endConnector="externalSetpoint"/>
        </ssd:Connections>
    </ssd:System>

    <ssd:Units>
        <ssc:Unit name="m">
            <ssc:BaseUnit m="1"/>
        </ssc:Unit>
        <ssc:Unit name="m/s">
            <ssc:BaseUnit m="1" s="-1"/>
        </ssc:Unit>
        <ssc:Unit name="N">
            <ssc:BaseUnit kg="1" m="1" s="-2"/>
        </ssc:Unit>
    </ssd:Units>

    <ssd:Terminals>
        <ssd:Terminal matchingRule="plug" name="com.example.ControlSignals"
                      terminalKind="com.example.ControlSignals">
            <ssd:Connectors>
                <ssd:Connector kind="local" name="position">
                    <ssc:Real unit="m"/>
                </ssd:Connector>
                <ssd:Connector kind="local" name="velocity">
                    <ssc:Real unit="m/s"/>
                </ssd:Connector>
                <ssd:Connector kind="local" name="force">
                    <ssc:Real unit="N"/>
                </ssd:Connector>
            </ssd:Connectors>
        </ssd:Terminal>
    </ssd:Terminals>

    <ssd:DefaultExperiment startTime="0.0" stopTime="10.0"/>

</ssd:SystemStructureDescription>

```