### PR TITLE
Add check for trailing spaces to pipeline

### DIFF
--- a/.github/workflows/build-spec.yml
+++ b/.github/workflows/build-spec.yml
@@ -114,3 +114,13 @@ jobs:
         user-email: ci@ssp-standard.org
         target-branch: main
         target-directory: static/docs/main
+
+  check-trailing-spaces:
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v4
+
+    - name: Check for trailing spaces
+      run: |
+        ! grep -rIn ' $' --exclude="*.svg" .

--- a/.github/workflows/build-spec.yml
+++ b/.github/workflows/build-spec.yml
@@ -114,3 +114,15 @@ jobs:
         user-email: ci@ssp-standard.org
         target-branch: main
         target-directory: static/docs/main
+
+  check-trailing-spaces:
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v4
+
+    - name: Check for trailing spaces
+      run: |
+        ! grep -rIn ' $' --include="*.adoc" --include="*.h" --include="*.c" \
+          --include="*.xsd" --include="*.xml" --include="*.yml" \
+          --include="*.txt" --include="*.ps1" .

--- a/.github/workflows/build-spec.yml
+++ b/.github/workflows/build-spec.yml
@@ -123,6 +123,6 @@ jobs:
 
     - name: Check for trailing spaces
       run: |
-        ! grep -rIn ' $' --include="*.adoc" --include="*.h" --include="*.c" \
-          --include="*.xsd" --include="*.xml" --include="*.yml" \
-          --include="*.txt" --include="*.ps1" .
+        ! grep -rIn ' $' --include="*.adoc" \
+          --include="*.xsd" --include="*.yml" \
+          --include="*.txt" .


### PR DESCRIPTION
Check for trailing spaces in all text files, except *.svg, since they are generated/exported by some tool.
Same as in FMI: https://github.com/modelica/fmi-standard/pull/2128